### PR TITLE
Fetcher GraphQL

### DIFF
--- a/utils/fetcher.ts
+++ b/utils/fetcher.ts
@@ -1,0 +1,40 @@
+async function fetcher<DataType>(
+  url: string,
+  query: string,
+  token: string,
+  variables?: Record<string, any>,
+  ): Promise<DataType> {
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json;charset=UTF-8",
+        "Authorization": `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        query,
+        variables
+      })
+    });
+
+    type JSONResponse = {
+      data?: DataType;
+      errors?: Array<{message: string}>;
+    }
+
+    const { data, errors }: JSONResponse = await response.json();
+
+    if (response?.ok) {
+      if ( data ) {
+        return data;
+      } else {
+        return Promise.reject(new Error("Failed to get data"));
+      }
+    } else {
+      // Handle the graphql errors
+      const error = new Error(errors?.map(error => error?.message).join('\n') ?? 'unknown')
+      return Promise.reject(error)
+    }
+}
+
+export default fetcher;

--- a/utils/getStrapi.ts
+++ b/utils/getStrapi.ts
@@ -1,6 +1,5 @@
-
 import { env } from "process";
-import { useState } from "react";
+import fetcher from "@/utils/fetcher";
 
 export const fetchStrapi = async (model: string, params: string[] ) => {
 
@@ -10,6 +9,21 @@ export const fetchStrapi = async (model: string, params: string[] ) => {
       }
     })
   }
+
+export async function fetchStrapiGraphQL<DataType> (
+  query: string,
+  variables?: Record<string, any>
+) {
+  const data = await fetcher<DataType>(
+    //@ts-ignore
+    process.env.NEXT_PUBLIC_STRAPI_GRAPHQL_API,
+    query,
+    process.env.NEXT_PUBLIC_STRAPI_GRAPHQL_TOKEN,
+    variables
+  );
+
+  return data;
+};
 
 export const replaceURL = (image: any, format?: string) => {
   let urlImage = format 


### PR DESCRIPTION
## Issue
Generate data fetching functions pointing to Strapi's GraphQL API's endpoint.

## Solution
- [X] Added `fetcher` util function.
- [X] Added `fetchStrapiGraphQL` util function.
- [X] Added `NEXT_PUBLIC_STRAPI_GRAPHQL_API` environment variable in Vercel's configuration settings.