### PR TITLE
[ENG-1161] Adjust OpenForm modality rules

### DIFF
--- a/forms/container/OpenForm.tsx
+++ b/forms/container/OpenForm.tsx
@@ -41,6 +41,18 @@ const getBusinessLineToFetchFrom = (businessLine: string, modality: string) => {
   }
 }
 
+const getLeadModality = (
+  modality: string // "Presencial" | "Online" | "Flex" | "Semipresencial"
+) => {
+  switch (modality) {
+    case "Presencial": return "Presencial";
+    case "Online": return "Online";
+    case "Flex": return "Online"; // Applies to "UANE" and "UTEG" offer.
+    case "Semipresencial": return "Semipresencial"; // Applies to "ULA" offer.
+    default: return "";
+  }
+};
+
 type OpenFormConfig = {
   title: string;
   subtitle: string;
@@ -222,7 +234,7 @@ const OpenForm = ({ config, classNames, pathThankyou, controls, data }: OpenForm
     const telefono = personalData?.phone;
     const email = personalData?.email;
     const lineaNegocio = selectedProgramData?.lineaNegocio || "";
-    const modalidad = academicData?.modality === "Presencial" ? "Presencial" : "Online";
+    const modalidad = getLeadModality(academicData?.modality);
     const nivel = academicData?.level;
     const campus = academicData?.campus;
     const { idPrograma: programa } = sourceData?.[academicData?.program]?.filter((campus: any) => {

--- a/forms/steps/step-two-openform.tsx
+++ b/forms/steps/step-two-openform.tsx
@@ -33,7 +33,7 @@ const getAvailableModalities = (): Array<SelectOptionConfig> => {
         },
       ];
     }
-    default: {
+    default: { // cases "UANE" and "UTEG"
       return [
         {
           value: "Presencial",

--- a/utils/getEducativeOffer.ts
+++ b/utils/getEducativeOffer.ts
@@ -66,8 +66,6 @@ export const getEducativeOffer = () => {
       .then( (res: any) => {
         const { data: programs } = res;
         let dataPrograms: Array<any> = [];
-        console.log("programs", programs);
-        console.log("programs Licenciatura", programs?.filter((program: any) => program?.nivel === "Licenciatura"))
         if(!!programs && !!programs.length) {
           setAllPrograms([ ...programs ])
           switch(modalidad) {
@@ -79,11 +77,11 @@ export const getEducativeOffer = () => {
               dataPrograms = filterOnlinePrograms(programs);
               break;
             }
-            case 'Flex': {
+            case 'Flex': { // Applies to "UANE" and "UTEG" offer
               dataPrograms = filterFlexPrograms(programs);
               break;
             }
-            case 'Semipresencial': {
+            case 'Semipresencial': { // Applies to "ULA" offer
               dataPrograms = filterHybridPrograms(programs);
               break;
             }


### PR DESCRIPTION
## Issue
ULA's hybrid ("Semipresencial") programs were being sent as `modalidad: "Online"`. Instead, they must be sent as `modalidad: "Semipresencial"` in the request's payload.

## Solution
- [X] Added `getLeadModality` function.

## Testing
- Checkout to PR.
- Run `yarn && yarn dev`.
- Navigate to `/`. You should see the `OpenForm` component at the bottom of the page.
- Fill in the fields and select any program under the "Semipresencial" category. Open up your developers console and submit the form.
- Look for the `captacion_prospecto` request and validate that `modalidad` is sent as "Semipresencial" and you're redirected to the `/thank-you` page.

![Captura de Pantalla 2023-09-26 a la(s) 15 08 40](https://github.com/techlottus/portalverse/assets/16314096/9890ac50-3067-472e-8d0e-fff11d4830bb)
