### PR TITLE
[ENG-1165] Fix Input Styles

### DIFF
--- a/old-components/Input/Input.scss
+++ b/old-components/Input/Input.scss
@@ -21,6 +21,7 @@ div {
           }
         }
       }
+      @apply text-xs font-texts font-normal #{!important};
     }
   }
 }


### PR DESCRIPTION
## Issue
Input texts are displaying in bold style due to a[ previously added CSS rule](https://github.com/techlottus/portalverse/commit/1e6ebd151e504a203fcb99905399ecd75194daff) being deleted.

## Solution
- [X] Add missing CSS rule.

## Testing
- Checkout to PR.
- Run `yarn && yarn dev`.
- Navigate to `/` and scroll down to the form. Validate that input's texts are no longer displayed in bold style.

![Captura de Pantalla 2023-09-26 a la(s) 18 59 57](https://github.com/techlottus/portalverse/assets/16314096/901d782c-93b3-4867-b9c2-5dffc85c3961)
