### PR TITLE
[ENG-1243] Add scroll y on modal component

### DIFF
--- a/old-components/Modal/Modal.tsx
+++ b/old-components/Modal/Modal.tsx
@@ -37,7 +37,7 @@ const Modal: FC<ModalData> = memo(({ data, isShow, children, className, onBtn, o
 
   return <section>
     <lottus-modal class="overflow-y-auto" ref={modalPortalverseRef}>
-      <div slot='areaModalContent' className={cn(className, "overflow-y-auto")}>
+      <div slot='areaModalContent' className={cn(className, "overflow-y-auto overflow-x-hidden h-135.5")}>
         { children }
       </div>
     </lottus-modal>


### PR DESCRIPTION
## Issue
We need to add scroll to modal component because the user can't close on mobile version

##Solution
h-135.5 class was added on div slot to generate the height of content and overflow-y-auto class works correctly