### PR TITLE
[ENG-753] Campus detail programs component

### DIFF
--- a/components/sections/ProgramAccordionList.tsx
+++ b/components/sections/ProgramAccordionList.tsx
@@ -1,0 +1,44 @@
+import Container from "@/layouts/Container.layout";
+import Accordion from "@/old-components/Accordion/Accordion";
+import routesConfig from "routesConfig.json";
+import type { ProgramAccordionListSection } from "@/utils/strapi/sections/ProgramAccordionItems";
+
+const ProgramAccordionList = (props: ProgramAccordionListSection) => {
+  const {
+    title,
+    programAccordionItems
+  } = props;
+
+  const formatAccordionItems = programAccordionItems?.map((programAccordionItem) => {
+    const title = programAccordionItem?.label;
+    const levelRoute = routesConfig?.educationalLevels?.find(educationalLevel => educationalLevel?.name === programAccordionItem?.level?.data?.attributes?.title)?.path;  
+    const answer = programAccordionItem?.programs?.data?.reduce((content, program) => (`${content}<a href="${levelRoute}/${program?.attributes?.slug}">${program?.attributes?.name}</a><br>`), "");
+
+    return {
+      title,
+      answer
+    }
+  });
+
+  if (!formatAccordionItems || formatAccordionItems?.length <= 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <Container>
+        {title ? (
+          <p className="font-headings font-bold text-10 w-t:text-7.5 w-p:text-7.5 leading-tight mb-6">
+            {title}
+          </p>
+        ) : null}
+        {
+          //@ts-ignore
+          <Accordion data={{ items: formatAccordionItems }} />
+        }
+      </Container>
+    </section>
+  );
+};
+
+export default ProgramAccordionList;

--- a/utils/Renderers.tsx
+++ b/utils/Renderers.tsx
@@ -4,6 +4,7 @@ import Banner from "@/components/sections/Banner";
 import BlogPostsPodcast from "@/components/sections/BlogPostsPodcast";
 import CardList from "@/components/sections/CardList";
 import ContactTargetList from "@/components/sections/ContactTargetList";
+import ContainerForm from "@/components/sections/ContainerForm";
 import ContEdPrograms from "@/components/sections/ContEdPrograms";
 import FAQ from "@/components/sections/FAQ";
 import FormVideo from "@/components/sections/FormVideo";
@@ -18,6 +19,7 @@ import OutstandingList from "@/components/sections/OutstandingList";
 import OverlayCardList from "@/components/sections/OverlayCardList";
 import Paragraph from "@/components/Paragraph";
 import PodcastList from "@/components/sections/PodcastList";
+import ProgramAccordionList from "@/components/sections/ProgramAccordionList";
 import ProgramsFilter from "@/components/sections/ProgramsFilter";
 import PromoLinkList from "@/components/sections/PromoLinkList";
 import RichTextImage from "@/components/sections/RichTextImage";
@@ -26,7 +28,6 @@ import StatisticsCardList from "@/components/sections/StatisticsCardList";
 import TextContent from "@/components/sections/TextContent";
 import WebError from "@/components/sections/WebError";
 import type { FC } from "react";
-import ContainerForm from "@/components/sections/ContainerForm";
 
 type Renderer = {
   [key: string]: FC<any>;
@@ -42,6 +43,7 @@ const defaultRenderers: Renderer = {
   ComponentSectionsContactTargetList: ContactTargetList,
   ComponentSectionsContEdPrograms: ContEdPrograms,
   ComponentSectionsFaqSection: FAQ,
+  ComponentSectionsFormContainer: ContainerForm,
   ComponentSectionsFormVideo: FormVideo,
   ComponentSectionsGoogleMap: GoogleMap,
   ComponentSectionsHeroSlider: HeroSlider,
@@ -53,14 +55,14 @@ const defaultRenderers: Renderer = {
   ComponentSectionsContainerOutstandingList: OutstandingList,
   ComponentSectionsOverlayCardList: OverlayCardList,
   ComponentSectionsPodcastList: PodcastList,
+  ComponentSectionsProgramAccordionList: ProgramAccordionList,
   ComponentSectionsProgramsFilter: ProgramsFilter,
   ComponentSectionsPromoLinkList: PromoLinkList,
   ComponentSectionsRichTextImage: RichTextImage,
+  ComponentSectionsRichTextVideo: RichTextVideo,
   ComponentSectionsStatisticsCardList: StatisticsCardList,
   ComponentSectionsTextContent: TextContent,
-  ComponentSectionsWebError: WebError,
-  ComponentSectionsRichTextVideo: RichTextVideo,
-  ComponentSectionsFormContainer: ContainerForm,
+  ComponentSectionsWebError: WebError
 };
 
 export default defaultRenderers;

--- a/utils/getFilteredPrograms.ts
+++ b/utils/getFilteredPrograms.ts
@@ -1,0 +1,51 @@
+import { fetchStrapiGraphQL } from "@/utils/getStrapi";
+
+export type FilteredProgramsVariables = {
+  level?: string;
+  modality?: string;
+  campus?: string;
+};
+
+export type FilteredProgramsResponse = {
+  programs: {
+    data: [
+      {
+        attributes: {
+          name: string;
+          slug: string;
+        }
+      }
+    ]
+  }
+};
+
+export const getFilteredPrograms = async(variables: FilteredProgramsVariables) => {
+  const data = await fetchStrapiGraphQL<FilteredProgramsResponse>(
+    FILTERED_PROGRAMS,
+    variables
+  );
+
+  return data;
+};
+
+const FILTERED_PROGRAMS = `
+query FilteredPrograms($level: String, $modality: String, $campus: String) {
+  programs(
+    sort: "name:asc",
+    pagination: { start: 0, limit: -1 }
+    filters: {
+      level: { title: { eq: $level } },
+      programModalities: {
+        modality: { name: { eq: $modality } },
+        curriculums: {campus: {name: {eq: $campus}} }
+      } 
+    }) {
+    data {
+      attributes {
+        name,
+        slug
+      }
+    }
+  }
+}
+`;

--- a/utils/getPageDataById.ts
+++ b/utils/getPageDataById.ts
@@ -5,6 +5,7 @@ import { formatContEdProgramsSection } from "@/utils/strapi/sections/ContEdProgr
 import { formatListconfigSection } from "@/utils/strapi/sections/Listconfig";
 import { formatModalityFilterSection } from "@/utils/strapi/sections/ModalityFilter";
 import { formatProgramsFilterSection } from "@/utils/strapi/sections/ProgramsFilter";
+import { formatOfferAccordionListSection } from "@/utils/strapi/sections/ProgramAccordionItems";
 import type { ComponentSection } from "@/utils/strapi/queries";
 
 type PageVariables = {
@@ -53,6 +54,10 @@ const formatPageData = async (data: PageResponse): Promise<PageResponse> => {
         }
         case "ComponentSectionsProgramsFilter": {
           const formattedData = await formatProgramsFilterSection(section);
+          return formattedData;
+        }
+        case "ComponentSectionsProgramAccordionList": {
+          const formattedData = await formatOfferAccordionListSection(section);
           return formattedData;
         }
         default:

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -6,6 +6,7 @@ import { CARD_LIST } from "@/utils/strapi/sections/CardList";
 import { CONTACT_TARGET_LIST } from "@/utils/strapi/sections/ContactTargetList";
 import { CONT_ED_PROGRAMS } from "@/utils/strapi/sections/ContEdPrograms";
 import { FAQ_SECTION } from "@/utils/strapi/sections/FAQ";
+import { FORM_CONTAINER } from "@/utils/strapi/sections/ContainerForm";
 import { FORM_VIDEO } from "@/utils/strapi/sections/FormVideo";
 import { GOOGLE_MAP } from "@/utils/strapi/sections/GoogleMap";
 import { HERO_SLIDER } from "@/utils/strapi/sections/HeroSlider";
@@ -14,11 +15,12 @@ import { LEADERBOARD } from "@/utils/strapi/sections/Leaderboard";
 import { LINK_LIST } from "@/utils/strapi/sections/LinkList";
 import { LIST_CONFIG } from "@/utils/strapi/sections/Listconfig";
 import { MODALITY_FILTER } from "@/utils/strapi/sections/ModalityFilter";
+import { OUTSTANDING_LIST } from "@/utils/strapi/sections/OutstandingList";
 import { OVERLAY_CARD_LIST } from "@/utils/strapi/sections/OverlayCardList";
 import { PODCAST_LIST } from "@/utils/strapi/sections/PodcastList";
+import { PROGRAM_ACCORDION_LIST,  } from "@/utils/strapi/sections/ProgramAccordionItems";
 import { PROGRAMS_FILTER } from "@/utils/strapi/sections/ProgramsFilter";
 import { PROMO_LINK_LIST } from "@/utils/strapi/sections/PromoLinkList";
-import { OUTSTANDING_LIST } from "@/utils/strapi/sections/OutstandingList";
 import { RICH_TEXT_IMAGE } from "@/utils/strapi/sections/RichTextImage";
 import { RICH_TEXT_VIDEO } from "@/utils/strapi/sections/RichTextVideo";
 import { STATISTICS_CARD_LIST } from "@/utils/strapi/sections/StatisticsCardList";
@@ -29,6 +31,7 @@ import type { BannerSection } from "@/utils/strapi/sections/Banner";
 import type { BlogPostsPodcastSection } from "@/utils/strapi/sections/BlogPostsPodcast";
 import type { CardListSection } from "@/utils/strapi/sections/CardList";
 import type { ContactTargetListSection } from "@/utils/strapi/sections/ContactTargetList";
+import type { ContainerForm } from "@/utils/strapi/sections/ContainerForm";
 import type { ContEdProgramsSection } from "@/utils/strapi/sections/ContEdPrograms";
 import type { FAQSection } from "@/utils/strapi/sections/FAQ";
 import type { FormVideoSection } from "@/utils/strapi/sections/FormVideo";
@@ -39,6 +42,7 @@ import type { LeaderboardSection } from "@/utils/strapi/sections/Leaderboard";
 import type { LinkListSection } from "@/utils/strapi/sections/LinkList";
 import type { ListconfigSection } from "@/utils/strapi/sections/Listconfig";
 import type { ModalityFilterSection } from "@/utils/strapi/sections/ModalityFilter";
+import type { ProgramAccordionListSection } from "@/utils/strapi/sections/ProgramAccordionItems";
 import type { OutstandingListSection } from "@/utils/strapi/sections/OutstandingList";
 import type { PodcastListSection } from "@/utils/strapi/sections/PodcastList";
 import type { ProgramsFilterSection } from "@/utils/strapi/sections/ProgramsFilter";
@@ -47,7 +51,6 @@ import type { RichTextImageSection } from "@/utils/strapi/sections/RichTextImage
 import type { RichTextVideoSection } from "@/utils/strapi/sections/RichTextVideo";
 import type { StatisticsCardListSection } from "@/utils/strapi/sections/StatisticsCardList";
 import type { TextContentSection } from "@/utils/strapi/sections/TextContent";
-import { ContainerForm, FORM_CONTAINER } from "./sections/ContainerForm";
 
 
 export type ComponentSection =
@@ -57,6 +60,7 @@ export type ComponentSection =
   | BlogPostsPodcastSection
   | CardListSection
   | ContactTargetListSection
+  | ContainerForm
   | ContEdProgramsSection
   | FAQSection
   | FormVideoSection
@@ -67,15 +71,15 @@ export type ComponentSection =
   | LinkListSection
   | ListconfigSection
   | ModalityFilterSection
+  | OutstandingListSection
   | PodcastListSection
+  | ProgramAccordionListSection
   | ProgramsFilterSection
   | PromoLinkListSection
-  | OutstandingListSection
   | RichTextImageSection
   | RichTextVideoSection
   | StatisticsCardListSection
   | TextContentSection
-  | ContainerForm
 
 export const SECTIONS = `
   ${ACCORDION_SECTION}
@@ -86,6 +90,7 @@ export const SECTIONS = `
   ${CONTACT_TARGET_LIST}
   ${CONT_ED_PROGRAMS}
   ${FAQ_SECTION}
+  ${FORM_CONTAINER}
   ${FORM_VIDEO}
   ${GOOGLE_MAP}
   ${HERO_SLIDER}
@@ -97,11 +102,11 @@ export const SECTIONS = `
   ${OUTSTANDING_LIST}
   ${OVERLAY_CARD_LIST}
   ${PODCAST_LIST}
-  ${PROMO_LINK_LIST}
+  ${PROGRAM_ACCORDION_LIST}
   ${PROGRAMS_FILTER}
+  ${PROMO_LINK_LIST}
   ${RICH_TEXT_IMAGE}
   ${RICH_TEXT_VIDEO}
   ${STATISTICS_CARD_LIST}
   ${TEXT_CONTENT}
-  ${FORM_CONTAINER}
 `;

--- a/utils/strapi/sections/ProgramAccordionItems.ts
+++ b/utils/strapi/sections/ProgramAccordionItems.ts
@@ -1,0 +1,91 @@
+import { getFilteredPrograms } from "@/utils/getFilteredPrograms";
+
+export type ProgramAccordionItem = {
+  label?: string;
+  level?: {
+    data: {
+      attributes: {
+        title: string;
+      }
+    }
+  },
+  campus?: {
+    data: {
+      attributes: {
+        name: string;
+      }
+    }
+  },
+  modality?: {
+    data: {
+      attributes: {
+        name: string;
+      }
+    }
+  },
+  programs?: {
+    data: Array<{
+      attributes: {
+        name: string;
+        slug: string;
+      }
+    }>
+  }
+};
+
+export type ProgramAccordionList = Array<ProgramAccordionItem>;
+
+export type ProgramAccordionListSection = {
+  type: "ComponentSectionsProgramAccordionList";
+  title: string;
+  programAccordionItems: ProgramAccordionList;
+};
+
+export const PROGRAM_ACCORDION_LIST = `
+...on ComponentSectionsProgramAccordionList {
+  __typename
+  title
+  programAccordionItems {
+    label
+    level {
+      data {
+        attributes {
+          title
+        }
+      }
+    }
+    modality {
+      data {
+        attributes {
+          name
+        }
+      }
+    }
+    campus {
+      data {
+        attributes {
+          name
+        }
+      }
+    }
+  }
+}
+`;
+
+export const formatOfferAccordionListSection = async (section: ProgramAccordionListSection) => {  
+  const formattedData = await Promise.all(section?.programAccordionItems?.map(async (offerAccordionItem) => {
+    const { level = null, modality = null, campus = null } = offerAccordionItem;
+    const levelName = level?.data?.attributes?.title;
+    const modalityName = modality?.data?.attributes?.name;
+    const campusName = campus?.data?.attributes?.name;
+
+    const filteredPrograms = await getFilteredPrograms({ level: levelName, modality: modalityName, campus: campusName });
+
+    return { ...offerAccordionItem, programs: filteredPrograms?.programs };
+  }));
+
+  return {
+    ...section,
+    programAccordionItems: formattedData
+  };
+};


### PR DESCRIPTION
## Issue
It's necessary to implement a component which renders and displays the programs that are offered in a campus by modality. 

This component should also enable users to display programas filtered according to different filters such as level, modality and/or campus (those three filters can be included/combined, etc). In addition, a label for each applied filtered should be displayed.

The list of programs for each filtered should be listed within an accordion element. The set of filtered programs consists of an accordion items list.

## Solution
- [X] Created FilteredPrograms type + query + utility ba10893.
- [X] Created ProgramAccordionItems section type + query + handler 40c060c.
- [X] Created ProgramAccordionList section renderer 29b186d.
- [X] Added ProgramAccordionList to renderers list 387c68f.
- [X] Added ProgramAccordionListSection to queries list 74617d0.
- [X] Added exception for ComponentSectionsProgramAccordionList 1fd3cd9.

## Testing
1. Checkout to PR & run `yarn` && `yarn dev`.
2. In the Strapi CMS implementation, either create a new page or go to an already created one. In order to create a section which displays this components, make sure there are Programs created, and at least one pulished element per Campus, Level and Modality.
3. Select the `ProgramAccordionList` from the available components of the sections field of the page entry.
4. Add at least one element to the list, each element correspond to a filtered list of program, which has a visual representation of an accordion item. If selected criteria (such as level, campus & modality) matches one or more programs, they are going to be displayed. Nothing is going to be displayed otherwise.
5. Step 4 can be repeated depending on how many filtered programs the user wants to be listed & displayed in a given page.
6. Once section if finished, make a Deploy through the vercel deploy plugin in the Strapi CMS in order to release latest changes of that page.
7. Go to the URL of the page, which is given by the `slug` field. Once located in the page, find the recently created section.
8. Validate that the accordion list displays data correctly & it matches the selected criteria in its corresponding counterpart in Strapi CMS.
9. The styles & visualization of that element can be validated in the following Figma mockup.
10. Enjoy 🍊.