### PR TITLE
[ENG-1300] Fix UANE/UTEG form bug

### DIFF
--- a/utils/getEducativeOffer.ts
+++ b/utils/getEducativeOffer.ts
@@ -23,7 +23,7 @@ const filterOnlinePrograms = (programs: any) => {
       return programs.filter((item: any) => item?.nivel !== "Educación Continua").reduce((prev: any, item: any) => item?.lineaNegocio === "ULA" && item?.nombreCampus === "ONLINE" ? [...prev, item] : [...prev], []);
     }
     default: { // UANE, UTEG
-      programs.reduce((prev: any, item: any) => (item?.lineaNegocio === process.env.NEXT_PUBLIC_LINEA && item?.modalidad === "Online") || (item?.lineaNegocio === "ULA" && (item?.nombreCampus === `${process.env.NEXT_PUBLIC_LINEA} ONLINE` && item?.modalidad === "Online")) ? [...prev, item] : [...prev], []);
+      return programs.reduce((prev: any, item: any) => (item?.lineaNegocio === process.env.NEXT_PUBLIC_LINEA && item?.modalidad === "Online") || (item?.lineaNegocio === "ULA" && (item?.nombreCampus === `${process.env.NEXT_PUBLIC_LINEA} ONLINE` && item?.modalidad === "Online")) ? [...prev, item] : [...prev], []);
     }
   }
 }


### PR DESCRIPTION
## Issue
Currently, when selecting Online modality in OpenForm it crashes due to a missing return statement in the reduce function which filters programs in this modality for UTEG & UANE business units.

## Solution
- [X] Added missing return to statement 39c6165.

## Testing
TODO