### PR TITLE
[ENG-1333]Update rockstars info component & page

### DIFF
--- a/components/sections/RockstarInfo.tsx
+++ b/components/sections/RockstarInfo.tsx
@@ -74,11 +74,11 @@ const RockstarInfo: FC<RockstarInfoSection> = (props: RockstarInfoSection) => {
           </div>
         </div>
         <div className="flex justify-center">
-          <p className="mt-4 font-headings text-5 w-p:text-base font-semibold leading-6 w-p:leading-4">
+          <p className="mt-2 font-headings text-center text-5 w-p:text-base font-semibold leading-6 w-p:leading-4">
             {name}
           </p>
         </div>
-        <div className="flex justify-center mt-4 text-primary-500">
+        <div className="flex justify-center mt-2 text-primary-500">
           <span
             onClick={() => {
               handleOpenModal(detail);

--- a/components/sections/RockstarInfoList.tsx
+++ b/components/sections/RockstarInfoList.tsx
@@ -1,17 +1,40 @@
-import React from "react";
+import React, { useState } from "react";
 import type { FC } from "react";
 import Container from "@/layouts/Container.layout"
 import RichtText from "@/old-components/Richtext/Richtext";
 import RockstarInfo from "@/components/sections/RockstarInfo";
 import parseEditorRawData from "@/utils/parseEditorRawData";
-import { RockstarInfoListSection } from "@/utils/strapi/sections/RockstarInfloList";
+import PaginatorPortalverse from "@/old-components/PaginatorPortalverse";
+import type { RockstarInfoListSection } from "@/utils/strapi/sections/RockstarInfloList";
 
 const RockstarInfoList: FC<RockstarInfoListSection> = (props: RockstarInfoListSection) => {
   const { title, description, rockstars } = props;
+  const pageSize = 16;
 
-  rockstars?.sort((a, b) => // sort programs alphabetically
+  const rockstarsData = rockstars?.sort((a, b) => // sort rockstars alphabetically
     a?.name < b?.name ? -1 : a?.name > b?.name ? 1 : 0
-  )
+  );
+
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const onPageChange = (page: any) => {
+    setCurrentPage(page);
+  };
+
+  if (rockstarsData?.length <= 0) {
+    return null;
+  }
+
+  const paginate = <T,>(items: Array<T>, pageNumber: number, pageSize: number) => {
+    const startIndex = (pageNumber - 1) * pageSize;
+    return items?.slice(startIndex, startIndex + pageSize);
+  };
+
+  const paginatedItems = paginate(
+    rockstarsData,
+    currentPage,
+    pageSize
+  );
 
   return (
     <section className="bg-surface-200 pb-14">
@@ -30,14 +53,17 @@ const RockstarInfoList: FC<RockstarInfoListSection> = (props: RockstarInfoListSe
         }
         {
           rockstars?.length > 0 ?
-            <div>
+            <div className="flex flex-col gap-4">
               <section className="col-span-12 grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-2">
                 {
-                  rockstars?.map((item: any, i: number) => <section key={`section-blog-${i}`}>
+                  paginatedItems?.map((item: any, i: number) => <section key={`section-blog-${i}`}>
                     <RockstarInfo {...item} type={"ComponentSectionsRockstarInfo"} />
                   </section>)
                 }
               </section>
+              <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 my-6 flex justify-center w-p:hidden">
+                <PaginatorPortalverse items={rockstars?.length} currentPage={currentPage} pageSize={pageSize} onPageChange={onPageChange} iconNext={"chevron_right"} iconPrevious={"chevron_left"} />
+              </div>
             </div>
             : null
         }

--- a/components/sections/RockstarInfoList.tsx
+++ b/components/sections/RockstarInfoList.tsx
@@ -54,11 +54,11 @@ const RockstarInfoList: FC<RockstarInfoListSection> = (props: RockstarInfoListSe
         {
           rockstars?.length > 0 ?
             <div className="flex flex-col gap-4">
-              <section className="col-span-12 grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-2">
+              <section className="col-span-12 grid w-d:grid-cols-4 w-t:grid-cols-2 w-p:grid-cols-2 w-p:gap-7 w-t:gap-10 w-d:gap-10">
                 {
-                  paginatedItems?.map((item: any, i: number) => <section key={`section-blog-${i}`}>
+                  paginatedItems?.map((item: any, i: number) => <div key={`section-blog-${i}`}>
                     <RockstarInfo {...item} type={"ComponentSectionsRockstarInfo"} />
-                  </section>)
+                  </div>)
                 }
               </section>
               <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 my-6 flex justify-center w-p:hidden">

--- a/old-components/PaginatorPortalverse.tsx
+++ b/old-components/PaginatorPortalverse.tsx
@@ -19,10 +19,9 @@ const PaginatorPortalverse: FC<PaginatorPortalverseData> = memo(({ items, curren
             onPageChange(currentPage)
           }    
         }}> 
-        <span className="material-icons flex justify-center items-center w-10 h-10 rounded-lg cursor-pointer m-2 hover:bg-surface-100" 
-          >
-          {iconPrevious}
-        </span>
+        <div className="flex justify-center items-center w-10 h-10 rounded-lg cursor-pointer m-2 hover:bg-surface-100">
+          <span className="material-icons">{iconPrevious}</span>
+        </div>
       </li>
        {pages.map((page) => (
          <li
@@ -43,10 +42,9 @@ const PaginatorPortalverse: FC<PaginatorPortalverseData> = memo(({ items, curren
             onPageChange(currentPage)
           }
         }}>
-        <span className="material-icons flex justify-center items-center w-10 h-10 rounded-lg cursor-pointer m-2 hover:bg-surface-100" 
-          >
-          {iconNext}
-        </span>
+        <div className="flex justify-center items-center w-10 h-10 rounded-lg cursor-pointer m-2 hover:bg-surface-100">
+          <span className="material-icons">{iconNext}</span>
+        </div>
       </li>
      </ul>
 


### PR DESCRIPTION
## Issue
It's required to update the Rockstars page in order to match certain criteria requested by the design team. This criteria consists on reducing the paddings of the elements within the Rockstar image + name + button. As well as adding the pagination element to the bottom of the rockstars list, showing 16 elements per page.

## Solution
- [X] Updated classes for rockstar info margins 45bcafa.
- [X] Updated pagination component e9aa106.
- [X] Added pagination to rockstar info page 492359f.
- [X] Updated gap within rockstars list 90bf6f4.

## Testing
1. Checkout to PR branch & run `yarn` && `yarn dev`.
2. Go to `/nosotros/claustro-rockstars`. Make sure you're connected to any of the production Strapi instances. If connected to local, then create the corresponding page element with the associated `slug`.
3.  Review the margins of each Rockstar element, as well as the pagination. NOTE: Pagination element will only show up if there are +1 elements to the pageSize value. In this case, it means that the pagination element will show if there are 16+1 elements (rockstars).
4. Enjoy. 🥝