### PR TITLE
[ENG-1595] Twilio Webchat font size proposal v1

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -35,3 +35,7 @@
   /* Support for IE. */
   font-feature-settings: 'liga';
 }
+
+.Twilio-RootContainer * {
+  font-size: 16px !important;
+}


### PR DESCRIPTION
## Issue
Currently the default font size for Twilio Flex Webchats on websites is 12px for all texts inside the Webchat elements. It's necessary to increase the font size of those text in order to provide more legibility over the chat messages.

## Solution
- [X] Added font styles for Twilio Webchat container f4e080a.

## Testing
TODO