### PR TITLE
[ENG-1656] Dev the new CardsVideoContent section

### DIFF
--- a/components/sections/CardsVideoContent.tsx
+++ b/components/sections/CardsVideoContent.tsx
@@ -1,0 +1,109 @@
+import { FC } from "react"
+import cn from "classnames";
+import Video from "@/old-components/Video";
+import Button from "@/old-components/Button/Button";
+import CardWebsite from "@/old-components/CardWebsite";
+import RichtText from "@/old-components/Richtext/Richtext";
+import parseEditorRawData from "@/utils/parseEditorRawData";
+import Container from "@/layouts/Container.layout";
+import { useRouter } from "next/router";
+import type { CardsVideoContentData } from "@/utils/strapi/sections/CardsVideoContent";
+
+const CardsVideoContent: FC<CardsVideoContentData> = (props: CardsVideoContentData) => {
+ const { title, subtitle, cards, textPositionCardsVideoContent, videoItem, button } = props
+ const formatDescription = parseEditorRawData(subtitle)
+ const router = useRouter();
+ console.log(props, "props")
+
+ const formattedCards = cards?.map((item, index) => {
+  const card = {
+   id: index?.toString(),
+   urlImage: item?.image?.data?.attributes?.url,
+   subtitle: item?.subtitle,
+   title: item?.title,
+   text: parseEditorRawData(item?.content),
+   type: item?.type,
+   border: true,
+   allContent: true,
+   height: "",
+   isShowCardWebsiteContent: true,
+   background: true,
+   link: true,
+   linkText: {
+    text: item?.linkText,
+    size: "",
+    isBold: false,
+    disabled: false,
+    id: "",
+    icon: "",
+    href: item?.linkUrl,
+    test: ""
+   },
+   linkIcon: {
+    text: "",
+    size: "",
+    isBold: false,
+    disabled: false,
+    id: "",
+    icon: "",
+    href: "",
+    test: ""
+   },
+   wrapper: true
+  }
+  return card
+ })
+
+ return <>
+  <section>
+   <Container>
+    {
+     title ?
+      <div>
+       <h3 className="font-headings font-bold text-10 leading-12 w-p:text-6 w-p:leading-7 mb-6">{title}</h3>
+      </div>
+      : null
+    }
+    {
+     subtitle ?
+      <div>
+       <RichtText data={{
+        content: formatDescription
+       }} />
+      </div>
+      : null
+    }
+    <div className={cn('w-d:flex gap-6', { "w-d:flex-row-reverse": textPositionCardsVideoContent === 'right' })}>
+     <div className="w-d:w-1/2 flex flex-col justify-center pb-4">
+      <Video data={{ options: { id: videoItem.providerId, type: 'single', controls: true } }} />
+     </div>
+     <div className="w-d:w-1/2 flex flex-col justify-center pb-4">
+      <section className="grid w-d:grid-cols-2 gap-6 w-t:grid-cols-2 w-p:grid-cols-1">
+       {
+        formattedCards?.map((item: any, i: number) => <section className="w-full mb-6" key={`section-blog-${i}`}>
+         <CardWebsite data={item} />
+        </section>)
+       }
+      </section>
+      <div className="flex justify-center">
+       <Button
+        dark
+        darkOutlined={button?.variant === "outlined_negative"}
+        data={{
+         title: button?.label,
+         icon: button?.iconName,
+         isExpand: false,
+        }}
+        onClick={() => {
+         router.push("egresados");
+        }}
+       />
+      </div>
+     </div>
+    </div>
+   </Container>
+  </section>
+ </>
+}
+
+export default CardsVideoContent

--- a/utils/Renderers.tsx
+++ b/utils/Renderers.tsx
@@ -5,6 +5,8 @@ import BannerNumeraliaSection from "@/components/sections/BannerNumeraliaSection
 import BlogPostsPodcast from "@/components/sections/BlogPostsPodcast";
 import CardList from "@/components/sections/CardList";
 import CardsStatistics from "@/components/sections/CardsStatistics";
+import CardsDetailContent from "@/components/sections/CardsDetailContent";
+import CardsVideoContent from "@/components/sections/CardsVideoContent";
 import ContactTargetList from "@/components/sections/ContactTargetList";
 import ContainerForm from "@/components/sections/ContainerForm";
 import ContEdPrograms from "@/components/sections/ContEdPrograms";
@@ -36,7 +38,6 @@ import type { FC } from "react";
 import RockstarInfo from "@/components/sections/RockstarInfo";
 import RockstarInfoList from "@/components/sections/RockstarInfoList";
 import VideosSection from "@/components/sections/VideosSection";
-import CardsDetailContent from "@/components/sections/CardsDetailContent";
 
 type Renderer = {
   [key: string]: FC<any>;
@@ -51,6 +52,8 @@ const defaultRenderers: Renderer = {
   ComponentSectionsBlogPostsPodcast: BlogPostsPodcast,
   ComponentSectionsCardList: CardList,
   ComponentSectionsCardsStatistics: CardsStatistics,
+  ComponentSectionsCardsDetailContent: CardsDetailContent,
+  ComponentSectionsCardsVideoContent: CardsVideoContent,
   ComponentSectionsContactTargetList: ContactTargetList,
   ComponentSectionsContEdPrograms: ContEdPrograms,
   ComponentSectionsFaqSection: FAQ,
@@ -80,7 +83,6 @@ const defaultRenderers: Renderer = {
   ComponentSectionsTextContent: TextContent,
   ComponentSectionsVideos: VideosSection,
   ComponentSectionsWebError: WebError,
-  ComponentSectionsCardsDetailContent: CardsDetailContent
 };
 
 export default defaultRenderers;

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -6,6 +6,7 @@ import { BLOG_POSTS_PODCAST } from "@/utils/strapi/sections/BlogPostsPodcast";
 import { CARD_LIST } from "@/utils/strapi/sections/CardList";
 import { CARD_STATISTICS } from "@/utils/strapi/sections/CardsStatistics";
 import { CARDS_DETAIL_CONTENT } from "@/utils/strapi/sections/CardsDetailContent";
+import { CARDS_VIDEO_CONTENT } from "@/utils/strapi/sections/CardsVideoContent";
 import { CONTACT_TARGET_LIST } from "@/utils/strapi/sections/ContactTargetList";
 import { CONT_ED_PROGRAMS } from "@/utils/strapi/sections/ContEdPrograms";
 import { FAQ_SECTION } from "@/utils/strapi/sections/FAQ";
@@ -41,6 +42,7 @@ import type { BlogPostsPodcastSection } from "@/utils/strapi/sections/BlogPostsP
 import type { CardListSection } from "@/utils/strapi/sections/CardList";
 import type { CardsDetailContentData } from "@/utils/strapi/sections/CardsDetailContent";
 import type { CardsStatisticsData } from "@/utils/strapi/sections/CardsStatistics";
+import type { CardsVideoContentData } from "@/utils/strapi/sections/CardsVideoContent";
 import type { ContactTargetListSection } from "@/utils/strapi/sections/ContactTargetList";
 import type { ContainerForm } from "@/utils/strapi/sections/ContainerForm";
 import type { ContEdProgramsSection } from "@/utils/strapi/sections/ContEdPrograms";
@@ -77,6 +79,7 @@ export type ComponentSection =
   | CardListSection
   | CardsDetailContentData
   | CardsStatisticsData
+  | CardsVideoContentData
   | ContactTargetListSection
   | ContainerForm
   | ContEdProgramsSection
@@ -104,7 +107,7 @@ export type ComponentSection =
   | TextContentSection
   | VideosSectionData
 
-export const SECTIONS = `
+  export const SECTIONS = `
   ${ACCORDION_SECTION}
   ${ALERT}
   ${BANNER}
@@ -113,6 +116,7 @@ export const SECTIONS = `
   ${CARD_LIST} 
   ${CARD_STATISTICS}
   ${CARDS_DETAIL_CONTENT}
+  ${CARDS_VIDEO_CONTENT}
   ${CONTACT_TARGET_LIST}
   ${CONT_ED_PROGRAMS}
   ${FAQ_SECTION}

--- a/utils/strapi/sections/CardsVideoContent.ts
+++ b/utils/strapi/sections/CardsVideoContent.ts
@@ -1,0 +1,54 @@
+import type { Card } from "@/utils/strapi/sections/CardList";
+import type { VideoItem } from "@/utils/strapi/sections/Videos";
+
+export type CardsVideoContentData = {
+ type: 'ComponentSectionsCardsVideoContent';
+ title: string;
+ subtitle: string;
+ cards: Array<Card>;
+ textPositionCardsVideoContent: string;
+ videoItem: VideoItem;
+ button?: {
+  label: string
+  variant: string
+  size: string
+  CTA: string
+  iconName: string
+}};
+
+export const CARDS_VIDEO_CONTENT = `
+... on ComponentSectionsCardsVideoContent {
+    title
+    subtitle
+    cards {
+      title
+      subtitle
+      type
+      content
+      linkUrl
+      linkText
+      image {
+        data {
+          id
+          attributes {
+            alternativeText
+            url
+          }
+        }
+      }
+      imageAspectRatio              
+    }
+    textPositionCardsVideoContent: textPosition
+    videoItem {
+     providerId
+     provider
+    }
+    button {
+      label
+      variant
+      size
+      iconName
+      CTA
+    }
+  }
+`

--- a/utils/strapi/sections/Videos.ts
+++ b/utils/strapi/sections/Videos.ts
@@ -1,4 +1,4 @@
-type VideoItem= {
+export type VideoItem= {
   provider: string;
   providerId: string;
 }


### PR DESCRIPTION
## Issue
Create the new CardsVideoContent section

## Solution
- [X] define query and type section 42b1f18
- [X] define render for CardsVideoContent f5211d6
- [X] add export video type for the videoItem element 39294f5

## Testing

1. Open terminal and execute yarn and yarn dev
2. Go to strap/admin
3. Use o create a new page
4. Add new section with "+" button
5. Select CardsVideoContent
6. Fill the fields 
7. Save and publish
8. Go to your slug page in localhost:3000/slug
9. Enjoy 🌮