### PR TITLE
[ENG-1915] Update Material Icons reference

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -7,6 +7,13 @@
 
 @import './utils.scss';
 
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 100 700;
+  src: url(https://fonts.gstatic.com/s/materialsymbolsoutlined/v156/kJEhBvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oFsLjBuVY.woff2) format('woff2');
+}
+
 // TODO: Delete "old-components" import when components migration is completed
 @import '../old-components/index.scss';
 @import '../components/index.scss';
@@ -15,25 +22,16 @@
   font-family: 'Material Icons';
   font-weight: normal;
   font-style: normal;
-  font-size: 16px;  /* Preferred icon size */
-  display: inline-block;
+  font-size: 24px;
   line-height: 1;
-  text-transform: none;
   letter-spacing: normal;
-  word-wrap: normal;
+  text-transform: none;
+  display: inline-block;
   white-space: nowrap;
+  word-wrap: normal;
   direction: ltr;
-  
-  /* Support for all WebKit browsers. */
+  -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
-  /* Support for Safari and Chrome. */
-  text-rendering: optimizeLegibility;
-  
-  /* Support for Firefox. */
-  -moz-osx-font-smoothing: grayscale;
-  
-  /* Support for IE. */
-  font-feature-settings: 'liga';
 }
 
 .Twilio-RootContainer * {


### PR DESCRIPTION
## Issue
Updated reference for Material Icons class by using references of the Material Symbols Outlined CSS selectors. That means that this is the implementation of the new version of material symbols outlined from Google, but with masked with the material icons class to not break current implementation of web sites icons.