### PR TITLE
[ENG-1960] Handle Material Symbols compatibility

### DIFF
--- a/components/ProgramSuperiorPageContent.tsx
+++ b/components/ProgramSuperiorPageContent.tsx
@@ -281,7 +281,7 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
                             className="flex items-center justify-end font-texts font-bold"
                           >
                             <span className="mr-1">Ver más</span>
-                            <span className="material-icons icon">chevron_right</span>
+                            <span className="material-symbols-outlined icon">chevron_right</span>
                           </Link>
                         </div>
                       </div>

--- a/components/sections/Alert.tsx
+++ b/components/sections/Alert.tsx
@@ -14,7 +14,7 @@ const Alert: FC<AlertSection> = (props: AlertSection) => {
         <div className="border-2 border-solid border-surface-300 rounded-lg flex space-x-4 items-start p-4">
           {
             iconName
-              ? <span className="material-icons text-surface-500 text-4.5!">{iconName}</span>
+              ? <span className="material-symbols-outlined text-surface-500 text-4.5!">{iconName}</span>
               : null
           }
           <div className="flex flex-col space-y-4">
@@ -38,7 +38,7 @@ const Alert: FC<AlertSection> = (props: AlertSection) => {
                           ? <a key={i} href={link?.href} target={link?.target === "blank" ? "_blank" : "_self"} rel={link?.target === "blank" ? "noreferrer" : undefined} className="flex items-center space-x-2">
                               {
                                 link?.iconName && link?.iconPosition === "left"
-                                  ? <span className="material-icons font-normal">{link?.iconName}</span>
+                                  ? <span className="material-symbols-outlined font-normal">{link?.iconName}</span>
                                   : null
                               }
                               {
@@ -48,7 +48,7 @@ const Alert: FC<AlertSection> = (props: AlertSection) => {
                               }
                               {
                                 link?.iconName && link?.iconPosition === "right"
-                                  ? <span className="material-icons font-normal">{link?.iconName}</span>
+                                  ? <span className="material-symbols-outlined font-normal">{link?.iconName}</span>
                                   : null
                               }
                             </a>

--- a/components/sections/AtrProgramInfo.tsx
+++ b/components/sections/AtrProgramInfo.tsx
@@ -115,23 +115,23 @@ const BenefitCard = (props: {
           <p className="font-texts font-bold text-sm text-surface-900">Beneficios:</p>
           <div className="flex flex-col gap-2">
             <div className="flex flex-row items-center gap-2">
-              <span className="material-icons !text-4.5 text-primary-400 select-none">book_2</span>
+              <span className="material-symbols-outlined !text-4.5 text-primary-400 select-none">book_2</span>
               <span className="font-texts font-normal text-sm text-surface-900">Aprendizaje autogestivo</span>
             </div>
             <div className="flex flex-row items-center gap-2">
-              <span className="material-icons !text-4.5 text-primary-400 select-none">card_membership</span>
+              <span className="material-symbols-outlined !text-4.5 text-primary-400 select-none">card_membership</span>
               <span className="font-texts font-normal text-sm text-surface-900">Título con Validez Oficial (SEP)</span>
             </div>
             <div className="flex flex-row items-center gap-2">
-              <span className="material-icons !text-4.5 text-primary-400 select-none">schedule</span>
+              <span className="material-symbols-outlined !text-4.5 text-primary-400 select-none">schedule</span>
               <span className="font-texts font-normal text-sm text-surface-900">Concluye en menos tiempo</span>
             </div>
             <div className="flex flex-row items-center gap-2">
-              <span className="material-icons !text-4.5 text-primary-400 select-none">savings</span>
+              <span className="material-symbols-outlined !text-4.5 text-primary-400 select-none">savings</span>
               <span className="font-texts font-normal text-sm text-surface-900">Único pago por suscripción mensual </span>
             </div>
             <div className="flex flex-row items-center gap-2">
-              <span className="material-icons !text-4.5 text-primary-400 select-none">school</span>
+              <span className="material-symbols-outlined !text-4.5 text-primary-400 select-none">school</span>
               <span className="font-texts font-normal text-sm text-surface-900">2 años mínimo</span>
             </div>
           </div>
@@ -151,7 +151,7 @@ const BenefitCard = (props: {
           <div className="flex flex-row items-center gap-1.5">
             {
               priceIcon ?
-                <span className={cn("material-icons !text-4.5 text-secondary-400 select-none", { "text-surface-900": disabled })}>{priceIcon}</span>
+                <span className={cn("material-symbols-outlined !text-4.5 text-secondary-400 select-none", { "text-surface-900": disabled })}>{priceIcon}</span>
               : null
             }
             <span className={cn("font-texts font-normal text-secondary-400", { "text-surface-900": disabled })}>{priceText}</span>

--- a/components/sections/CardsDetailContent.tsx
+++ b/components/sections/CardsDetailContent.tsx
@@ -80,7 +80,7 @@ const CardsDetailContent: FC<CardsDetailContentData> = (props: CardsDetailConten
              ? <a key={i} href={link?.href} target={link?.target === "blank" ? "_blank" : "_self"} rel={link?.target === "blank" ? "noreferrer" : undefined} className="flex text-bold items-center space-x-2 pb-3">
               {
                link?.iconName && link?.iconPosition === "left"
-                ? <span className="material-icons font-normal">{link?.iconName}</span>
+                ? <span className="material-symbols-outlined font-normal">{link?.iconName}</span>
                 : null
               }
               {
@@ -90,7 +90,7 @@ const CardsDetailContent: FC<CardsDetailContentData> = (props: CardsDetailConten
               }
               {
                link?.iconName && link?.iconPosition === "right"
-                ? <span className="material-icons font-normal">{link?.iconName}</span>
+                ? <span className="material-symbols-outlined font-normal">{link?.iconName}</span>
                 : null
               }
              </a>

--- a/components/sections/CategoryAccordionList.tsx
+++ b/components/sections/CategoryAccordionList.tsx
@@ -51,7 +51,7 @@ const CategoryAccordionList: FC<CategoryAccordionListData> = (props: CategoryAcc
                       <div className="flex justify-start mb-5 gap-2.5 items-center" key={index}>
                         {
                           item?.iconName
-                            ? <span className={cn("material-icons flex-none !text-4.5 w-4", { "text-primary-500": index === optionSelect })}>{item?.iconName}</span>
+                            ? <span className={cn("material-symbols-outlined flex-none !text-4.5 w-4", { "text-primary-500": index === optionSelect })}>{item?.iconName}</span>
                             : null
                         }
                         <button className={cn("font-semibold font-headings text-left !text-4.5", { "text-primary-500": index === optionSelect })} onClick={() => {

--- a/components/sections/GoogleMap.tsx
+++ b/components/sections/GoogleMap.tsx
@@ -47,23 +47,23 @@ const GoogleMap: FC<GoogleMapSection> = (props: GoogleMapSection) => {
                   <div className={cn("flex flex-col items-start space-y-4 w-d:w-2/5 w-full w-d:p-0 pb-4", { "w-d:px-6": detailPosition === 'right' })}>
                     <h1>{name}</h1>
                     {address && <div className="flex flex-col items-start space-y-2">
-                      <span className="material-icons font-normal">location_on</span>
+                      <span className="material-symbols-outlined font-normal">location_on</span>
                       <span className="font-bold text-surface-600">Dirección</span>
                       <span className="font-normal text-surface-600 hover:underline">{address}</span>
                     </div>}
                     {admissionPhone &&
                       <div className="flex flex-col items-start space-y-2">
-                        <span className="material-icons font-normal">call</span>
+                        <span className="material-symbols-outlined font-normal">call</span>
                         <span className="font-bold text-surface-600">Teléfono Admisiones:</span>
                         <span className="font-normal text-surface-600 hover:underline">{admissionPhone}</span>
                       </div>}
                     {receptionPhone && <div className="flex flex-col items-start space-y-2">
-                      <span className="material-icons font-normal">call</span>
+                      <span className="material-symbols-outlined font-normal">call</span>
                       <span className="font-bold text-surface-600">Teléfono Admisiones:</span>
                       <span className="font-normal text-surface-600 hover:underline">{receptionPhone}</span>
                     </div>}
                     {schedule && <div className="flex flex-col items-start space-y-2">
-                      <span className="material-icons font-normal">event_available</span>
+                      <span className="material-symbols-outlined font-normal">event_available</span>
                       <span className="font-bold text-surface-600">Horarios:</span>
                       <span className="font-normal text-surface-600 hover:underline">{schedule}</span>
                     </div>}
@@ -84,19 +84,19 @@ const GoogleMap: FC<GoogleMapSection> = (props: GoogleMapSection) => {
                     <h1 className="font-Poppins text-10 pb-4 font-bold leading-[125%] w-t:text-8.5 w-p:text-6">{name}</h1>
                     <div className="flex flex-col items-start space-y-4 w-d:w-2/5 right-0">
                       {address && <div className="flex items-center space-y-2 space-x-2 ">
-                        <span className="material-icons font-normal">location_on</span>
+                        <span className="material-symbols-outlined font-normal">location_on</span>
                         <span className="font-normal text-surface-600 hover:underline">{address}</span>
                       </div>}
                       {admissionPhone && <div className="flex  items-center space-y-2 space-x-2">
-                        <span className="material-icons font-normal">call</span>
+                        <span className="material-symbols-outlined font-normal">call</span>
                         <span className="font-normal text-surface-600 hover:underline">{admissionPhone}</span>
                       </div>}
                       {receptionPhone && <div className="flex  items-center space-y-2 space-x-2">
-                        <span className="material-icons font-normal">call</span>
+                        <span className="material-symbols-outlined font-normal">call</span>
                         <span className="font-normal text-surface-600 hover:underline">{receptionPhone}</span>
                       </div>}
                       {schedule && <div className="flex items-center space-y-2 space-x-2">
-                        <span className="material-icons font-normal">event_available</span>
+                        <span className="material-symbols-outlined font-normal">event_available</span>
                         <span className="font-normal text-surface-600 hover:underline">{schedule}</span>
                       </div>}</div>
                   </div>

--- a/components/sections/IconTextImageList.tsx
+++ b/components/sections/IconTextImageList.tsx
@@ -53,7 +53,7 @@ const IconTextListImage: FC<IconTextListImage> = (props: IconTextListImage) => {
                   iconTextList?.map((item: any, i: number) =>
                     <div key={`icon-${i}`} className="flex gap-6">
                       <div className="my-auto">
-                        <span className={cn("material-icons text-primary-500 !text-16", iconClassNames)}>{item?.icon}</span>
+                        <span className={cn("material-symbols-outlined text-primary-500 !text-16", iconClassNames)}>{item?.icon}</span>
                       </div>
                       <div className="">
                         <p className="font-headings font-bold">{item?.title}</p>

--- a/components/sections/KnowledgeAreaFilter.tsx
+++ b/components/sections/KnowledgeAreaFilter.tsx
@@ -153,7 +153,7 @@ const KnowledgeAreaFilter = (props: KnowledgeAreaFilterSection) => {
                                     className="flex items-center justify-end font-texts font-bold"
                                   >
                                     <span className="mr-1">Ver más</span>
-                                    <span className="material-icons icon">
+                                    <span className="material-symbols-outlined icon">
                                       chevron_right
                                     </span>
                                   </Link>

--- a/components/sections/Leaderboard.tsx
+++ b/components/sections/Leaderboard.tsx
@@ -71,7 +71,7 @@ const Leaderboard = (props: LeaderboardSection) => {
                 ? <div className="flex items-center space-x-2">
                   {
                     subtitleIcon
-                      ? <span className={cn("material-icons font-normal", {
+                      ? <span className={cn("material-symbols-outlined font-normal", {
                         "text-surface-0": overlayLeaderboard === "dark",
                         "text-surface-950": overlayLeaderboard === "white"
                       })}>{subtitleIcon}</span>
@@ -124,7 +124,7 @@ const Leaderboard = (props: LeaderboardSection) => {
                         >
                           {
                             link?.iconName
-                              ? <span className={cn("material-icons font-normal", {
+                              ? <span className={cn("material-symbols-outlined font-normal", {
                                 "text-surface-0": overlayLeaderboard === "dark",
                                 "text-surface-950": overlayLeaderboard === "white"
                               })}>{link?.iconName}</span>

--- a/components/sections/LinkList.tsx
+++ b/components/sections/LinkList.tsx
@@ -24,7 +24,7 @@ const LinkList: FC<LinkListSection> = memo((props: LinkListSection) => {
                           ? <a key={i} href={link?.href} target={link?.target === "blank" ? "_blank" : "_self"} rel={link?.target === "blank" ? "noreferrer" : undefined} className="flex items-center space-x-2">
                               {
                                 link?.iconName && link?.iconPosition === "left"
-                                  ? <span className="material-icons font-normal">{link?.iconName}</span>
+                                  ? <span className="material-symbols-outlined font-normal">{link?.iconName}</span>
                                   : null
                               }
                               {
@@ -34,7 +34,7 @@ const LinkList: FC<LinkListSection> = memo((props: LinkListSection) => {
                               }
                               {
                                 link?.iconName && link?.iconPosition === "right"
-                                  ? <span className="material-icons font-normal">{link?.iconName}</span>
+                                  ? <span className="material-symbols-outlined font-normal">{link?.iconName}</span>
                                   : null
                               }
                             </a>

--- a/components/sections/ModalityFilter.tsx
+++ b/components/sections/ModalityFilter.tsx
@@ -137,7 +137,7 @@ const ModalityFilter = (props: ModalityFilterSection) => {
                                     className="flex items-center justify-end font-texts font-bold"
                                   >
                                     <span className="mr-1">Ver más</span>
-                                    <span className="material-icons icon">
+                                    <span className="material-symbols-outlined icon">
                                       chevron_right
                                     </span>
                                   </Link>

--- a/components/sections/ProgramsFilter.tsx
+++ b/components/sections/ProgramsFilter.tsx
@@ -190,7 +190,7 @@ const ProgramsFilter: FC<ProgramsFilterSection> = (props: ProgramsFilterSection)
                               className="flex items-center justify-end font-texts font-bold"
                             >
                               <span className="mr-1">Ver más</span>
-                              <span className="material-icons icon">chevron_right</span>
+                              <span className="material-symbols-outlined icon">chevron_right</span>
                             </Link>
                           </div>
                         </div>

--- a/components/sections/RockstarInfo.tsx
+++ b/components/sections/RockstarInfo.tsx
@@ -83,7 +83,7 @@ const RockstarInfo: FC<RockstarInfoSection> = (props: RockstarInfoSection) => {
             onClick={() => {
               handleOpenModal(detail);
             }}
-            className="material-icons cursor-pointer text-6"
+            className="material-symbols-outlined cursor-pointer text-6"
           >
             add_circle
           </span>

--- a/components/sections/RvoeAccordionList.tsx
+++ b/components/sections/RvoeAccordionList.tsx
@@ -49,7 +49,7 @@ const RvoeAccordionList: FC<RvoeAccordionListData> = (props: RvoeAccordionListDa
                       <div className="flex justify-start items-center mb-5 border-b pb-2 lg:border-0" key={item?.label}>
                         {
                           item?.iconName
-                            ? <span className={cn("material-icons text-4.5! mr-2", { "text-primary-500": index === optionSelect })}>{item?.iconName}</span>
+                            ? <span className={cn("material-symbols-outlined text-4.5! mr-2", { "text-primary-500": index === optionSelect })}>{item?.iconName}</span>
                             : null
                         }
                         <button className={cn("text-base font-Poppins font-semibold !text-4.5 text-left", { "text-primary-500": index === optionSelect })} onClick={() => {
@@ -77,7 +77,7 @@ const RvoeAccordionList: FC<RvoeAccordionListData> = (props: RvoeAccordionListDa
                           <>
                             <Disclosure.Button className="flex flex-row justify-between w-full border-b p-5">
                               <p className="font-texts text-sm	lg:text-base">Nivel {level}</p>
-                              <span className={open ? 'rotate-180 transform material-icons' : 'material-icons'} >expand_more</span>
+                              <span className={open ? 'rotate-180 transform material-symbols-outlined' : 'material-symbols-outlined'} >expand_more</span>
                             </Disclosure.Button>
                             <Disclosure.Panel className="p-2 lg:p-5 bg-gray-100">
                               <table className="w-full bg-white table-auto">

--- a/forms/steps/step-three-openform.tsx
+++ b/forms/steps/step-three-openform.tsx
@@ -118,7 +118,7 @@ const StepThree: FC<any> = ({ classNames, step, data, contacts, schedulers, onNe
         </div>
       </div>
       <div className="cursor-pointer" onClick={handleChangeInfo}>
-        <span className="material-icons icons">edit_square</span>
+        <span className="material-symbols-outlined icons">edit_square</span>
       </div>
     </div>
     <form>

--- a/old-components/BannerNumeralia/BannerNumeralia.scss
+++ b/old-components/BannerNumeralia/BannerNumeralia.scss
@@ -22,6 +22,12 @@
                     font-size: 24px !important;
                   }
                 }
+                span.material-icons {
+                  font-size: 40px !important;
+                  @media (max-width: 599px) {
+                    font-size: 24px !important;
+                  }
+                }
               }
             }
             .body {

--- a/old-components/BannerNumeralia/BannerNumeralia.scss
+++ b/old-components/BannerNumeralia/BannerNumeralia.scss
@@ -16,7 +16,7 @@
                 }
               }
               div.prefix {
-                span.material-icons {
+                span.material-symbols-outlined {
                   font-size: 40px !important;
                   @media (max-width: 599px) {
                     font-size: 24px !important;

--- a/old-components/Breadcrumbs/BreadcrumbPortalverse.tsx
+++ b/old-components/Breadcrumbs/BreadcrumbPortalverse.tsx
@@ -6,7 +6,7 @@ import BreadcrumbsComponentData from "@/types/BreadcrumbsPortalverse.types"
 import StaticPagesBreadcrumbsLabels from "@/routes/breadcrumbs.labels"
 
 const Breadcrumbs: FC<BreadcrumbsComponentData> = ({ visible = true, classNames, breadcrumbs = {} }: BreadcrumbsComponentData) => {
-  const mainRoute = <span className="material-icons mr-1">home</span>;
+  const mainRoute = <span className="material-symbols-outlined mr-1">home</span>;
   const { asPath } = useRouter();
   const [ allRoutes, setAllRoutes ] = useState<Array<string>>([]);
 

--- a/old-components/Breadcrumbs/Breadcrumbs.scss
+++ b/old-components/Breadcrumbs/Breadcrumbs.scss
@@ -1,5 +1,8 @@
 ul.breadcrumbs {
   li {
+    span.material-symbols-outlined {
+      font-size: 14px !important;
+    }
     span.material-icons {
       font-size: 14px !important;
     }

--- a/old-components/CardProgram/CardProgram.tsx
+++ b/old-components/CardProgram/CardProgram.tsx
@@ -28,7 +28,7 @@ const CardProgram: FC<CardProgramData> = memo(({ title, subtitle, link, image, c
       <p className={cn("font-texts font-normal text-4.5 mb-2 mx-3", {"mt-3": !subtitle})}>{title}</p>
       <div className="w-full h-full flex justify-end pb-2 font-texts font-bold items-end">
         <LinkIcons data={link} onClick={onClick}/>
-        <span className="material-icons icon">chevron_right</span>
+        <span className="material-symbols-outlined icon">chevron_right</span>
       </div>
       </div>
     </div>

--- a/old-components/CarouselCards/CarouselCards.tsx
+++ b/old-components/CarouselCards/CarouselCards.tsx
@@ -7,7 +7,7 @@ const CarouselCards: FC<any> = ({ data: { items }, classNames, classNameSlide }:
   const [ active, setActive ] = useState<number>(0);
   const [ countItems, setCountItems ] = useState<number>(0);
 
-  const stylesBaseControls = "material-icons select-none absolute top-1/2 p-1 rounded-lg text-xs w-p:hidden";
+  const stylesBaseControls = "material-symbols-outlined select-none absolute top-1/2 p-1 rounded-lg text-xs w-p:hidden";
 
   useEffect(() => {
     setCountItems((items.length - 1));

--- a/old-components/Cintillo.tsx
+++ b/old-components/Cintillo.tsx
@@ -102,7 +102,7 @@ const CintilloContent = (props: CintilloData) => {
               ? <div className="flex my-4 items-center">
                 <span
                   className={cn(
-                    "material-icons pr-2 pt-1 text-2 text-surface-950 w-p:text-surface-0",
+                    "material-symbols-outlined pr-2 pt-1 text-2 text-surface-950 w-p:text-surface-0",
                     {
                       "!text-surface-0": contentVariant === "light" || overlay === "dark",
                       "!text-surface-950": overlay === "white"
@@ -123,7 +123,7 @@ const CintilloContent = (props: CintilloData) => {
               ? <div className="flex my-4 items-center">
                 <span
                   className={cn(
-                    "material-icons pr-2 pt-1 text-2 text-surface-950 w-p:text-surface-0",
+                    "material-symbols-outlined pr-2 pt-1 text-2 text-surface-950 w-p:text-surface-0",
                     {
                       "!text-surface-0": contentVariant === "light" || overlay === "dark",
                       "!text-surface-950": overlay === "white"

--- a/old-components/Filter/Filter.tsx
+++ b/old-components/Filter/Filter.tsx
@@ -62,7 +62,7 @@ const Filter: FC<FilterComponentConfig> = memo(({ data, color = "#000", onSelect
       </section>
       {/* <div className="flex items-center justify-end cursor-pointer mt-6" onClick={changeMosaicView}>
         <span className="mr-1 font-texts font-normal">Ver en { mosaicActive ? "lista" : "mosaico" }</span>
-        <span className="material-icons icon">{ mosaicActive ? "format_list_bulleted" : "space_dashboard" }</span>
+        <span className="material-symbols-outlined icon">{ mosaicActive ? "format_list_bulleted" : "space_dashboard" }</span>
       </div> */}
     </section>
 });

--- a/old-components/FilterDropdown/FilterDropdown.tsx
+++ b/old-components/FilterDropdown/FilterDropdown.tsx
@@ -64,9 +64,9 @@ const FilterDropdown: FC<FilterDropdownComponentData> = memo(({ data: { config, 
 
   return <section className="relative">
     <section className="dropdown" onClick={onOpenClose}>
-      <span className= "material-icons icon text-primary-500 w-p:!hidden">{ configComponent.icon }</span>
+      <span className= "material-symbols-outlined icon text-primary-500 w-p:!hidden">{ configComponent.icon }</span>
       <p className={cn(`font-texts font-normal text-surface-950`)}>{ configComponent.label }</p>
-      <span className="material-icons icon" onClick={onOpenClose}>expand_{ open ? 'less' : 'more' }</span>
+      <span className="material-symbols-outlined icon" onClick={onOpenClose}>expand_{ open ? 'less' : 'more' }</span>
     </section>
     <section className="dropdown-list absolute w-full top-11 bg-surface-0 z-10" style={{ display: open ? 'flex' : 'none' }}>
       {

--- a/old-components/HeaderPortalverse/HeaderPortalverse.scss
+++ b/old-components/HeaderPortalverse/HeaderPortalverse.scss
@@ -1,4 +1,7 @@
 p.submenu {
+  span.material-symbols-outlined {
+    font-size: 18px !important;
+  }
   span.material-icons {
     font-size: 18px !important;
   }

--- a/old-components/HeaderPortalverse/HeaderPortalverse.tsx
+++ b/old-components/HeaderPortalverse/HeaderPortalverse.tsx
@@ -140,7 +140,7 @@ const Header: FC<HeaderPortalverseComponentData> = ({ classNames, onClickLogo, o
                       : <p className="font-texts font-bold text-sm">{item.label}</p>
                   }
                   <p className={cn("flex items-center justify-center", { "hidden": !item.items.length })} onClick={() => !activeMenu ? handleHoverOption(item.label): handleHoverOutOption()}>
-                    <span className={cn("material-icons ml-2")}>expand_more</span>
+                    <span className={cn("material-symbols-outlined ml-2")}>expand_more</span>
                   </p>
                   </div>)
               }
@@ -205,7 +205,7 @@ const Header: FC<HeaderPortalverseComponentData> = ({ classNames, onClickLogo, o
                       </div>
                 }
                 <div className={cn("p-3", { "cursor-pointer": !!item.route })} onClick={() => handleEventNavigate(!!item.route, item.label, "arrow", !!item.back)}>
-                  <span className="material-icons icon">{ !item.back ? "arrow_forward_ios" : "arrow_back_ios" }</span>
+                  <span className="material-symbols-outlined icon">{ !item.back ? "arrow_forward_ios" : "arrow_back_ios" }</span>
                 </div>
               </div>
           </div>)

--- a/old-components/IntroducctionProgram.tsx
+++ b/old-components/IntroducctionProgram.tsx
@@ -89,7 +89,7 @@ const IntroductionProgram: FC<IntroductionProgramData> = (props: IntroductionPro
                       {
                         programPerks?.map((item, i) => (<div key={i}>
                           <div className="flex items-center gap-2 p-2">
-                            <span className="material-icons my-auto text-surface-500 !text-[32px] select-none">{item?.attributes?.iconName}</span>
+                            <span className="material-symbols-outlined my-auto text-surface-500 !text-[32px] select-none">{item?.attributes?.iconName}</span>
                             <div className="flex flex-col">
                               <p className="font-texts font-normal text-xs leading-4">{item?.attributes?.title}</p>
                               <p className="font-texts font-bold text-base leading-5">{item?.attributes?.subtitle}</p>
@@ -162,7 +162,7 @@ const IntroductionProgram: FC<IntroductionProgramData> = (props: IntroductionPro
                                   {
                                     brands?.[0]?.attributes?.contact ?
                                       <div className="flex items-center gap-1">
-                                        <span className="material-icons !text-lg text-primary-500 select-none">email</span>
+                                        <span className="material-symbols-outlined !text-lg text-primary-500 select-none">email</span>
                                         <a
                                           className="font-texts font-bold text-base text-primary-500 leading-5 underline"
                                           target="_blank"

--- a/old-components/NumbersPortalverse/NumbersPortalverse.tsx
+++ b/old-components/NumbersPortalverse/NumbersPortalverse.tsx
@@ -37,7 +37,7 @@ const NumbersPortalverse: FC<NumbersPortalverseData> = memo(({data, classNames }
           data?.icon ?
             <p
               className={cn(
-                "icono material-icons pr-2 !text-10 text-surface-500",
+                "icono material-symbols-outlined pr-2 !text-10 text-surface-500",
                 `${iconsClassNames}`,
                 "w-p:hidden w-p:invisible w-t:invisible w-p:w-0 w-t:w-0"
                 )}

--- a/old-components/PaginatorPortalverse.tsx
+++ b/old-components/PaginatorPortalverse.tsx
@@ -20,7 +20,7 @@ const PaginatorPortalverse: FC<PaginatorPortalverseData> = memo(({ items, curren
           }    
         }}> 
         <div className="flex justify-center items-center w-10 h-10 rounded-lg cursor-pointer m-2 hover:bg-surface-100">
-          <span className="material-icons">{iconPrevious}</span>
+          <span className="material-symbols-outlined">{iconPrevious}</span>
         </div>
       </li>
        {pages.map((page) => (
@@ -43,7 +43,7 @@ const PaginatorPortalverse: FC<PaginatorPortalverseData> = memo(({ items, curren
           }
         }}>
         <div className="flex justify-center items-center w-10 h-10 rounded-lg cursor-pointer m-2 hover:bg-surface-100">
-          <span className="material-icons">{iconNext}</span>
+          <span className="material-symbols-outlined">{iconNext}</span>
         </div>
       </li>
      </ul>

--- a/old-components/SliderImagesPortalverse.tsx
+++ b/old-components/SliderImagesPortalverse.tsx
@@ -8,7 +8,7 @@ const Slider: FC<SliderPortalverseComponentData> = ({ data: { items }, className
   const [ active, setActive ] = useState<number>(0);
   const [ countItems, setCountItems ] = useState<number>(0);
 
-  const stylesBaseControls = "material-icons select-none absolute top-1/2 p-1 rounded-lg text-xs";
+  const stylesBaseControls = "material-symbols-outlined select-none absolute top-1/2 p-1 rounded-lg text-xs";
 
   useEffect(() => {
     setCountItems((items.length - 1));

--- a/old-components/SliderPortalverse.tsx
+++ b/old-components/SliderPortalverse.tsx
@@ -179,7 +179,7 @@ const SliderPortalverse: FC<SliderPortalverseProps> = (
               , stylesBaseControls
             )}
           >
-          <span className="material-icons ml-2 pointer-events-none">arrow_back_ios</span>
+          <span className="material-symbols-outlined ml-2 pointer-events-none">arrow_back_ios</span>
         </div>
         <section className="w-full h-full flex overflow-hidden">
           {
@@ -265,7 +265,7 @@ const SliderPortalverse: FC<SliderPortalverseProps> = (
               { "bg-surface-0/50 cursor-pointer": countItems > 1 }, stylesBaseControls
             )}
           >
-            <span className="material-icons ml-0.5 pointer-events-none">arrow_forward_ios</span>
+            <span className="material-symbols-outlined ml-0.5 pointer-events-none">arrow_forward_ios</span>
           </div>
         </div>
       </Aspect>

--- a/old-components/Table.tsx
+++ b/old-components/Table.tsx
@@ -17,7 +17,7 @@ const Table:FC<TableData> = memo(({ data, classNames } : TableData) => {
       <thead>
         <tr>
           <th className='text-surface-0 text-base font-texts bg-primary-200 px-4 py-2.5 border border-solid border-surface-100 rounded-trounded-t-lg flex justify-between'>
-          <span className=''>{data.head}</span><span className='material-icons'>{data.icon}</span>
+          <span className=''>{data.head}</span><span className='material-symbols-outlined'>{data.icon}</span>
         </th>
         </tr>
       </thead>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,8 +9,8 @@ export default function Document() {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
         <link rel="icon" href={favicon} crossOrigin="true" />
-        { links.map((value: any, i: number) => <link key={i} href={value} rel="stylesheet"></link>) }
-
+        {/* { links.map((value: any, i: number) => <link key={i} href={value} rel="stylesheet"></link>) } */}
+        <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
       </Head>
       <body>
         

--- a/pages/admisiones/becas.tsx
+++ b/pages/admisiones/becas.tsx
@@ -76,7 +76,7 @@ const ModeloEducativo: NextPageWithLayout = ({ sections, meta }: any) => {
                 const children = (
                   <>
                     <span className="font-texts font-normal underline underline-offset-4 mr-auto">{redirect?.label}</span>
-                    <span className="material-icons ml-3 mt-1">
+                    <span className="material-symbols-outlined ml-3 mt-1">
                       {
                         redirect?.external ?
                           "chevron_right"

--- a/pages/admisiones/index.tsx
+++ b/pages/admisiones/index.tsx
@@ -116,7 +116,7 @@ const LandindAdmissions: NextPageWithLayout = ({ sections, meta }: any) => {
                                 iconTextList?.map((item: any, i: number) =>
                                   <div key={`icon-${i}`} className="flex gap-6">
                                     <div className="my-auto">
-                                      <span className={cn("material-icons text-primary-500 !text-14")}>{item?.icon}</span>
+                                      <span className={cn("material-symbols-outlined text-primary-500 !text-14")}>{item?.icon}</span>
                                     </div>
                                     <div className="my-auto">
                                       <p className="font-headings font-bold">{item?.title}</p>

--- a/pages/contactanos/faq/[section].tsx
+++ b/pages/contactanos/faq/[section].tsx
@@ -42,7 +42,7 @@ const FAQ: NextPageWithLayout<any> = ({ info, meta, sections }: any) => {
               info.map((section: any, i:number) => <Link key={`section-item${i}`} href={`${section.route}`}>
 
                 <li className={cn("font-headings font-bold flex py-2 w-t:py-4 w-p:py-4 w-t:px-6 w-p:px-6 w-t:border-solid border-surface-200 w-t:border w-p:border-solid w-p:border items-center", { "text-primary-500": section.status, "text-surface-950": !section.status })}>
-                  <span className="material-icons icon pr-3">{section.icon}</span>
+                  <span className="material-symbols-outlined icon pr-3">{section.icon}</span>
                   <p>{ section.title }</p>
                 </li>
 

--- a/pages/contactanos/index.tsx
+++ b/pages/contactanos/index.tsx
@@ -30,7 +30,7 @@ const PonteEnContacto: NextPageWithLayout = ({ sections, meta }: any) => {
               </div>
               <h1 className="col-span-5 col-start-2 col-end-5 w-t:col-span-8 w-t:col-start-2 w-t:col-end-8 w-p:col-start-1 w-p:col-end-5 text-10 w-p:text-7.5 w-p:m-6 font-bold font-headings leading-tight">{ sections.head.title }</h1>
               {
-                sections.medios.map((medio: any, i: number) => <p key={`item-media-${i}`} className="col-span-5 col-start-2 col-end-5 w-t:col-start-2 w-t:col-end-8 w-p:col-start-1 text-base font-headings w-d:mt-6 w-t:mt-6 w-p:mt-2 w-p:mx-6 leading-6 w-t:leading-tight w-p:leading-3[130%] flex items-center font-normal"><span className="material-icons mr-2">{ medio.icon }</span>{ medio.text }</p>)
+                sections.medios.map((medio: any, i: number) => <p key={`item-media-${i}`} className="col-span-5 col-start-2 col-end-5 w-t:col-start-2 w-t:col-end-8 w-p:col-start-1 text-base font-headings w-d:mt-6 w-t:mt-6 w-p:mt-2 w-p:mx-6 leading-6 w-t:leading-tight w-p:leading-3[130%] flex items-center font-normal"><span className="material-symbols-outlined mr-2">{ medio.icon }</span>{ medio.text }</p>)
               }
               <section className="col-span-5 col-start-2 col-end-5 w-t:col-start-2 w-t:col-end-8 w-p:col-start-1">
                 <p className="text-4.5 w-t:text-6 font-headings font-bold w-d:mt-6 w-t:mt-6 w-p:mt-2 w-p:mx-6 leading-tight">{sections.campus.title}</p>

--- a/pages/nosotros/campus.tsx
+++ b/pages/nosotros/campus.tsx
@@ -176,7 +176,7 @@ const Campus = ({ sections, meta }: any) => {
                             {
                               description?.link ?
                                 <ContentInsideLayout classNames="items-center">
-                                  <span className="material-icons col-span-1 w-t:col-span-1 w-p:col-span-1 w-4 mt-2 text-surface-500">{description?.link?.icon}</span>
+                                  <span className="material-symbols-outlined col-span-1 w-t:col-span-1 w-p:col-span-1 w-4 mt-2 text-surface-500">{description?.link?.icon}</span>
                                   <span className="col-span-11 w-t:col-span-7 w-p:col-span-3 mt-2 font-texts font-normal text-base leading-5 text-surface-500"><a className="hover:underline" target="_blank" rel="noreferrer noopener" href={description?.link?.redirect}>{description?.link?.text}</a></span>
                                 </ContentInsideLayout>
                                 : null

--- a/pages/nosotros/conexion-educativa.tsx
+++ b/pages/nosotros/conexion-educativa.tsx
@@ -64,7 +64,7 @@ const ConexionEducativa: NextPageWithLayout = ({ sections, meta }: any) => {
           <div className="flex sm:gap-2 md:gap-0 md:flex-row md:items-center">
             <p className="font-headings font-bold mr-6">{sections.head.contactText}</p>
             <div className="flex md:items-center">
-              <span className="material-icons text-surface-950 mr-2">mail</span>
+              <span className="material-symbols-outlined text-surface-950 mr-2">mail</span>
               <LinkContactTarget type={"email"} classNames="text-surface-950 underline" info={sections.head.contactLink} />
             </div>
           </div>
@@ -136,7 +136,7 @@ const ConexionEducativa: NextPageWithLayout = ({ sections, meta }: any) => {
                 content: sections.head.feedback.text
               }} classNames="mb-4" />
               <div className="flex align-middle items-center">
-                <span className="material-icons text-surface-500 mr-2">mail</span>
+                <span className="material-symbols-outlined text-surface-500 mr-2">mail</span>
                 <LinkContactTarget classNames="!font-bold underline" type={"email"} info={sections.head.feedback.contact} />
               </div>
             </div>

--- a/pages/nosotros/internacionalizacion.tsx
+++ b/pages/nosotros/internacionalizacion.tsx
@@ -51,7 +51,7 @@ const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: a
                           const children = (
                             <>
                               <span className="font-texts font-normal underline underline-offset-4 mr-auto">{redirect?.label}</span>
-                              <span className="material-icons ml-3 mt-1">download</span>
+                              <span className="material-symbols-outlined ml-3 mt-1">download</span>
                             </>
                           );
 
@@ -97,7 +97,7 @@ const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: a
                         }
                       >
                         <span className="font-texts font-normal underline underline-offset-4 mr-auto">{infoModal?.redirect?.link}</span>
-                        <span className="material-icons ml-3 mt-1">chevron_right</span>
+                        <span className="material-symbols-outlined ml-3 mt-1">chevron_right</span>
                       </a>
                   </div>
                 : null

--- a/pages/nosotros/planteles/index.tsx
+++ b/pages/nosotros/planteles/index.tsx
@@ -176,7 +176,7 @@ const Planteles = ({ sections, meta }: any) => {
                             {
                               description?.link ?
                                 <ContentInsideLayout classNames="items-center">
-                                  <span className="material-icons col-span-1 w-t:col-span-1 w-p:col-span-1 w-4 mt-2 text-surface-500">{description?.link?.icon}</span>
+                                  <span className="material-symbols-outlined col-span-1 w-t:col-span-1 w-p:col-span-1 w-4 mt-2 text-surface-500">{description?.link?.icon}</span>
                                   <span className="col-span-11 w-t:col-span-7 w-p:col-span-3 mt-2 font-texts font-normal text-base leading-5 text-surface-500"><a className="hover:underline" target="_blank" rel="noreferrer noopener" href={description?.link?.redirect}>{description?.link?.text}</a></span>
                                 </ContentInsideLayout>
                                 : null

--- a/pages/nosotros/vinculacion-empresarial.tsx
+++ b/pages/nosotros/vinculacion-empresarial.tsx
@@ -64,7 +64,7 @@ const VinculacionEmpresarial: NextPageWithLayout = ({ sections, meta }: any) => 
           <div className="flex sm:gap-2 md:gap-0 md:flex-row md:items-center">
             <p className="font-headings font-bold mr-6">{sections.head.contactText}</p>
             <div className="flex md:items-center">
-              <span className="material-icons text-surface-950 mr-2">mail</span>
+              <span className="material-symbols-outlined text-surface-950 mr-2">mail</span>
               <LinkContactTarget type={"email"} classNames="text-surface-950 underline" info={sections.head.contactLink} />
             </div>
           </div>
@@ -136,7 +136,7 @@ const VinculacionEmpresarial: NextPageWithLayout = ({ sections, meta }: any) => 
                 content: sections.head.feedback.text
               }} classNames="mb-4" />
               <div className="flex align-middle items-center">
-                <span className="material-icons text-surface-500 mr-2">mail</span>
+                <span className="material-symbols-outlined text-surface-500 mr-2">mail</span>
                 <LinkContactTarget classNames="!font-bold underline" type={"email"} info={sections.head.feedback.contact} />
               </div>
             </div>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -8,9 +8,8 @@
 @import './utils.scss';
 
 @font-face {
-  font-family: 'Material Icons';
+  font-family: 'Material Symbols Outlined';
   font-style: normal;
-  font-weight: 100 700;
   src: url(https://fonts.gstatic.com/s/materialsymbolsoutlined/v156/kJEhBvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oFsLjBuVY.woff2) format('woff2');
 }
 
@@ -18,8 +17,8 @@
 @import '../old-components/index.scss';
 @import '../components/index.scss';
 
-.material-icons {
-  font-family: 'Material Icons';
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
   font-weight: normal;
   font-style: normal;
   font-size: 24px;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -31,7 +31,16 @@
   word-wrap: normal;
   direction: ltr;
   -webkit-font-feature-settings: 'liga';
+
   -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
 }
 
 .Twilio-RootContainer * {


### PR DESCRIPTION
## Issue
Added Material Symbols Outlined to styles + fonts, as well as replaced all `material-icons classes` to `material-symbols-outline` class.