### PR TITLE
[POR-21] Render alt text in ColorCardList section

### DIFF
--- a/components/sections/ColorCardsList.tsx
+++ b/components/sections/ColorCardsList.tsx
@@ -7,7 +7,7 @@ import type { ColorCardListData } from "@/utils/strapi/sections/ColorCardsList";
 
 const ColorCardList: FC<ColorCardListData> = (props: ColorCardListData) => {
 
-  const {title, description, cards} = props;
+  const {title, description, cards, alternativeText} = props;
 
   const formattedDescription = parseEditorRawData(description)
 
@@ -64,6 +64,11 @@ const ColorCardList: FC<ColorCardListData> = (props: ColorCardListData) => {
           </div>
           : null
         }
+        <div className="flex justify-end mt-1">
+          <RichtText data={{
+            content:parseEditorRawData( alternativeText)
+          }} />
+        </div>
       </Container>
     </section>
   );

--- a/utils/strapi/sections/ColorCardsList.ts
+++ b/utils/strapi/sections/ColorCardsList.ts
@@ -10,6 +10,7 @@ export type ColorCardListData = {
   type: "ComponentSectionsColorCardList"
   title: string;
   description: string;
+  alternativeText: string;
   cards: Array<ColorCard>;  
 }
 
@@ -17,6 +18,7 @@ export const COLOR_CARD_LIST = `
 ...on ComponentSectionsColorCardList{
   title
   description
+  alternativeText
   cards {
     headline
     title


### PR DESCRIPTION
## Issue
- We need to add alternativeText to query ColorCardList section
- We need to add render to alternativeText on ColorCardList section

## Solution
- alternativeText on query was added
- alternativeText on type was added
- alternativeText on renderer was added


