### PR TITLE
[LOT-1039] Add to the head the seo parameters from strapi

### DIFF
--- a/components/BlogEntryPageContent.tsx
+++ b/components/BlogEntryPageContent.tsx
@@ -65,6 +65,8 @@ const BlogEntryPageContent = (props: BlogEntryPageData) => {
         <meta name="viewport" content={blogPost?.seo?.metaViewport} />
         {/* canonicalURL */}
         <link rel="canonical" href={blogPost?.seo?.canonicalURL} />
+        {/* ogURL */}
+        <link rel="og:url" href={blogPost?.seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/BlogEntryPageContent.tsx
+++ b/components/BlogEntryPageContent.tsx
@@ -66,7 +66,7 @@ const BlogEntryPageContent = (props: BlogEntryPageData) => {
         {/* canonicalURL */}
         <link rel="canonical" href={blogPost?.seo?.canonicalURL} />
         {/* ogURL */}
-        <link rel="og:url" href={blogPost?.seo?.canonicalURL} />
+        <meta property="og:url" content={blogPost?.seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/BlogEntryPageContent.tsx
+++ b/components/BlogEntryPageContent.tsx
@@ -26,8 +26,6 @@ const BlogEntryPageContent = (props: BlogEntryPageData) => {
 
   const structuredData = JSON.stringify(blogPost?.seo?.structuredData)
 
-  console.log(props)
-
   return (
     <Fragment>
       <Head>

--- a/components/BlogEntryPageContent.tsx
+++ b/components/BlogEntryPageContent.tsx
@@ -24,26 +24,60 @@ const BlogEntryPageContent = (props: BlogEntryPageData) => {
 
   const banners = attributes?.sections;
 
+  const structuredData = JSON.stringify(blogPost?.seo?.structuredData)
+
+  console.log(props)
+
   return (
     <Fragment>
       <Head>
         <title>{blogPost?.title}</title>
-        {/* TODO: Add SEO */}
-        <meta property="og:title" content={ blogPost?.seo?.metaTitle }/>
-        <meta property="title" content={ blogPost?.seo?.metaTitle }/>
-        <meta property="og:description" content={ blogPost?.seo?.metaDescription }/>
-        <meta name="description" content={blogPost?.seo?.metaDescription} key="desc" />
-        <meta property="og:image" content={blogPost?.seo?.metaImage?.data?.attributes?.url}/>
-        <meta property="image" content={blogPost?.seo?.metaImage?.data?.attributes?.url}/>
+        {/* THIS DATA COMES FROM STRAPI SEO */}
+        <meta property="title" content={blogPost?.seo?.metaTitle} />{/* metaTitle */}
+        <meta name="description" content={blogPost?.seo?.metaDescription} key="desc" />{/* metaDescription */}
+        <meta property="image" content={blogPost?.seo?.metaImage?.data?.attributes?.url} />{/* metaImage */}
+        {/* metaSocial */}
+        {/* ARRAY COULD BRING FACEBOOK OR TWITTER */}
+        {
+          blogPost?.seo?.metaSocial?.map((metasocial) => {
+            if (metasocial?.socialNetwork === "Facebook") {
+              return (
+                <>
+                  <meta property="og:title" content={metasocial?.title} />
+                  <meta property="og:description" content={metasocial?.description} />
+                  <meta property="og:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            } if (metasocial?.socialNetwork === "Twitter") {
+              return (
+                <>
+                  <meta property="twitter:title" content={metasocial?.title} />
+                  <meta property="twitter:description" content={metasocial?.description} />
+                  <meta property="twitter:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            }
+          })
+        }
+        {/* keywords */}
+        <meta name="keywords" content={blogPost?.seo?.keywords} />
+        {/* metaRobots */}
+        <meta name="robots" content={blogPost?.seo?.metaRobots} />
+        {/* metaViewport */}
+        <meta name="viewport" content={blogPost?.seo?.metaViewport} />
+        {/* canonicalURL */}
+        <link rel="canonical" href={blogPost?.seo?.canonicalURL} />
+        {/* structuredData */}
+        <script type="application/ld+json">{structuredData}</script>
       </Head>
       <ContentLayout>
         {
           blogPost?.title
             ? <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 w-d:col-start-1 w-d:col-end-8">
-                <p className="font-headings font-bold text-13 w-t:text-8.5 w-p:text-6 leading-tight">
-                  {blogPost?.title}
-                </p>
-              </div>
+              <p className="font-headings font-bold text-13 w-t:text-8.5 w-p:text-6 leading-tight">
+                {blogPost?.title}
+              </p>
+            </div>
             : null
         }
         <div className="col-span-8 w-t:col-span-0 w-p:col-span-4">
@@ -51,13 +85,13 @@ const BlogEntryPageContent = (props: BlogEntryPageData) => {
             {
               blogPostImageUrl
                 ? <Aspect ratio="2/1">
-                    <Image
-                      alt={ blogPostImageAltText || "" }
-                      src={ blogPostImageUrl }
-                      classNames="w-full h-full"
-                      classNamesImg="w-full h-full object-cover"
-                        />
-                  </Aspect>
+                  <Image
+                    alt={blogPostImageAltText || ""}
+                    src={blogPostImageUrl}
+                    classNames="w-full h-full"
+                    classNamesImg="w-full h-full object-cover"
+                  />
+                </Aspect>
                 : null
             }
             {
@@ -107,44 +141,46 @@ const BlogEntryPageContent = (props: BlogEntryPageData) => {
         {
           banners?.length > 0
             ? <Fragment>
-                {/** Dental clínic banner: Desk */}
-                  <div className="col-span-4 w-t:hidden w-p:hidden w-d:grid-cols-1 flex flex-col space-y-6">
-                    {
-                      banners?.map((banner, i) => {
-                        return (
-                          <BannerPortalverseWrapper
-                            key={i}
-                            data={banner}
-                            onClick={() => {
-                              const ctaUrl = banner?.ctaUrl;
-                              if (!ctaUrl) return;
-                              router.push(ctaUrl);
-                            }}
-                          />
-                        )}
-                      )
-                    }
-                  </div>
+              {/** Dental clínic banner: Desk */}
+              <div className="col-span-4 w-t:hidden w-p:hidden w-d:grid-cols-1 flex flex-col space-y-6">
+                {
+                  banners?.map((banner, i) => {
+                    return (
+                      <BannerPortalverseWrapper
+                        key={i}
+                        data={banner}
+                        onClick={() => {
+                          const ctaUrl = banner?.ctaUrl;
+                          if (!ctaUrl) return;
+                          router.push(ctaUrl);
+                        }}
+                      />
+                    )
+                  }
+                  )
+                }
+              </div>
 
-                  {/** Dental clínic & CESEPCOM banner: Tablet & Mobile */}
-                  <section className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-2 gap-6 w-t:grid-cols-2 w-p:grid-cols-1 w-d:hidden">
-                    {
-                      banners?.map((banner, i) => {
-                        return (
-                          <BannerPortalverseWrapper
-                            key={i}
-                            data={banner}
-                            onClick={() => {
-                              const ctaUrl = banner?.ctaUrl;
-                              if (!ctaUrl) return;
-                              router.push(ctaUrl);
-                            }}
-                          />
-                        )}
-                      )
-                    }
-                  </section>
-                </Fragment>
+              {/** Dental clínic & CESEPCOM banner: Tablet & Mobile */}
+              <section className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-2 gap-6 w-t:grid-cols-2 w-p:grid-cols-1 w-d:hidden">
+                {
+                  banners?.map((banner, i) => {
+                    return (
+                      <BannerPortalverseWrapper
+                        key={i}
+                        data={banner}
+                        onClick={() => {
+                          const ctaUrl = banner?.ctaUrl;
+                          if (!ctaUrl) return;
+                          router.push(ctaUrl);
+                        }}
+                      />
+                    )
+                  }
+                  )
+                }
+              </section>
+            </Fragment>
             : null
         }
       </ContentLayout>

--- a/components/ProgramBachilleratoPageContent.tsx
+++ b/components/ProgramBachilleratoPageContent.tsx
@@ -136,6 +136,8 @@ const ProgramBachilleratoPageContent = (props: DynamicProgramDetailData) => {
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
         <link rel="canonical" href={seo?.canonicalURL} />
+        {/* ogURL */}
+        <link rel="og:url" href={seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/ProgramBachilleratoPageContent.tsx
+++ b/components/ProgramBachilleratoPageContent.tsx
@@ -135,9 +135,9 @@ const ProgramBachilleratoPageContent = (props: DynamicProgramDetailData) => {
         {/* metaViewport */}
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
-        <meta property="og:url" content={seo?.canonicalURL} />
+        <link rel="canonical" href={seo?.canonicalURL} />
         {/* ogURL */}
-        <link rel="og:url" href={seo?.canonicalURL} />
+        <meta property="og:url" content={seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/ProgramBachilleratoPageContent.tsx
+++ b/components/ProgramBachilleratoPageContent.tsx
@@ -54,6 +54,9 @@ const ProgramBachilleratoPageContent = (props: DynamicProgramDetailData) => {
   const campusDetail = formattedModalityData?.curriculumsByCampus
   const hasCampuses = campusDetail?.some((option) => { return !!option?.campusName })
 
+  const structuredData = JSON.stringify(seo?.structuredData)
+
+
   //bandera para habilitar botón de descarga hasta que se seleccione un campus
   const isOptionSelected = !!selectedOption
 
@@ -98,13 +101,43 @@ const ProgramBachilleratoPageContent = (props: DynamicProgramDetailData) => {
   return (
     <Fragment>
       <Head>
-        <title>{title}</title>
-        <meta property="og:title" content={seo?.metaTitle} />
-        <meta property="title" content={seo?.metaTitle} />
-        <meta property="og:description" content={seo?.metaDescription} />
-        <meta name="description" content={seo?.metaDescription} key="desc" />
-        <meta property="og:image" content={seo?.metaImage?.data?.attributes?.url} />
-        <meta property="image" content={seo?.metaImage?.data?.attributes?.url} />
+        {/* THIS DATA COMES FROM STRAPI SEO */}
+        <meta property="title" content={seo?.metaTitle} />{/* metaTitle */}
+        <meta name="description" content={seo?.metaDescription} key="desc" />{/* metaDescription */}
+        <meta property="image" content={seo?.metaImage?.data?.attributes?.url} />{/* metaImage */}
+        {/* metaSocial */}
+        {/* ARRAY COULD BRING FACEBOOK OR TWITTER */}
+        {
+          seo?.metaSocial?.map((metasocial) => {
+            if (metasocial?.socialNetwork === "Facebook") {
+              return (
+                <>
+                  <meta property="og:title" content={metasocial?.title} />
+                  <meta property="og:description" content={metasocial?.description} />
+                  <meta property="og:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            } if (metasocial?.socialNetwork === "Twitter") {
+              return (
+                <>
+                  <meta property="twitter:title" content={metasocial?.title} />
+                  <meta property="twitter:description" content={metasocial?.description} />
+                  <meta property="twitter:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            }
+          })
+        }
+        {/* keywords */}
+        <meta name="keywords" content={seo?.keywords} />
+        {/* metaRobots */}
+        <meta name="robots" content={seo?.metaRobots} />
+        {/* metaViewport */}
+        <meta name="viewport" content={seo?.metaViewport} />
+        {/* canonicalURL */}
+        <link rel="canonical" href={seo?.canonicalURL} />
+        {/* structuredData */}
+        <script type="application/ld+json">{structuredData}</script>
       </Head>
       <ContentLayout>
         <div className="col-span-6 w-t:col-span-8 w-p:col-span-4 w-d:mb-12 flex flex-col w-d:justify-center">

--- a/components/ProgramBachilleratoPageContent.tsx
+++ b/components/ProgramBachilleratoPageContent.tsx
@@ -135,7 +135,7 @@ const ProgramBachilleratoPageContent = (props: DynamicProgramDetailData) => {
         {/* metaViewport */}
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
-        <link rel="canonical" href={seo?.canonicalURL} />
+        <meta property="og:url" content={seo?.canonicalURL} />
         {/* ogURL */}
         <link rel="og:url" href={seo?.canonicalURL} />
         {/* structuredData */}

--- a/components/ProgramSuperiorPageContent.tsx
+++ b/components/ProgramSuperiorPageContent.tsx
@@ -228,7 +228,7 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
         {/* metaViewport */}
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
-        <link rel="canonical" href={seo?.canonicalURL} />
+        <meta property="og:url" content={seo?.canonicalURL} />
         {/* ogURL */}
         <link rel="og:url" href={seo?.canonicalURL} />
         {/* structuredData */}

--- a/components/ProgramSuperiorPageContent.tsx
+++ b/components/ProgramSuperiorPageContent.tsx
@@ -228,9 +228,9 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
         {/* metaViewport */}
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
-        <meta property="og:url" content={seo?.canonicalURL} />
+        <link rel="canonical" href={seo?.canonicalURL} />
         {/* ogURL */}
-        <link rel="og:url" href={seo?.canonicalURL} />
+        <meta property="og:url" content={seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/ProgramSuperiorPageContent.tsx
+++ b/components/ProgramSuperiorPageContent.tsx
@@ -230,6 +230,8 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
         <link rel="canonical" href={seo?.canonicalURL} />
+        {/* ogURL */}
+        <link rel="og:url" href={seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/ProgramSuperiorPageContent.tsx
+++ b/components/ProgramSuperiorPageContent.tsx
@@ -39,6 +39,7 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
   const SFprogram = program.attributes.nombreProgramaSalesforce
   const layout = props?.layout as ProgramDetailSuperiorData;
   const seo = props?.program?.attributes?.seo
+  const structuredData = JSON.stringify(seo?.structuredData)
   const title = program?.attributes?.name;
   const description = program?.attributes?.description;
   const levelProgram = program?.attributes?.level?.data?.attributes?.title;
@@ -194,13 +195,43 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
   return (
     <Fragment>
       <Head>
-        <title>{title}</title>
-        <meta property="og:title" content={ seo?.metaTitle }/>
-        <meta property="title" content={ seo?.metaTitle }/>
-        <meta property="og:description" content={ seo?.metaDescription }/>
-        <meta name="description" content={seo?.metaDescription} key="desc" />
-        <meta property="og:image" content={seo?.metaImage?.data?.attributes?.url}/>
-        <meta property="image" content={seo?.metaImage?.data?.attributes?.url}/>
+        {/* THIS DATA COMES FROM STRAPI SEO */}
+        <meta property="title" content={seo?.metaTitle} />{/* metaTitle */}
+        <meta name="description" content={seo?.metaDescription} key="desc" />{/* metaDescription */}
+        <meta property="image" content={seo?.metaImage?.data?.attributes?.url} />{/* metaImage */}
+        {/* metaSocial */}
+        {/* ARRAY COULD BRING FACEBOOK OR TWITTER */}
+        {
+          seo?.metaSocial?.map((metasocial) => {
+            if (metasocial?.socialNetwork === "Facebook") {
+              return (
+                <>
+                  <meta property="og:title" content={metasocial?.title} />
+                  <meta property="og:description" content={metasocial?.description} />
+                  <meta property="og:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            } if (metasocial?.socialNetwork === "Twitter") {
+              return (
+                <>
+                  <meta property="twitter:title" content={metasocial?.title} />
+                  <meta property="twitter:description" content={metasocial?.description} />
+                  <meta property="twitter:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            }
+          })
+        }
+        {/* keywords */}
+        <meta name="keywords" content={seo?.keywords} />
+        {/* metaRobots */}
+        <meta name="robots" content={seo?.metaRobots} />
+        {/* metaViewport */}
+        <meta name="viewport" content={seo?.metaViewport} />
+        {/* canonicalURL */}
+        <link rel="canonical" href={seo?.canonicalURL} />
+        {/* structuredData */}
+        <script type="application/ld+json">{structuredData}</script>
       </Head>
       <Modal isShow={isShow} onClose={() => handleVisibilityModal('close')} data={{ icon: 'close', title: "", tagOnClose: 'testOnClose', wrapper: true, }}>
         <div className="mt-16">

--- a/components/ProgramSuperiorPageContent.tsx
+++ b/components/ProgramSuperiorPageContent.tsx
@@ -159,7 +159,7 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
 
   // }, [SFdata])
   const downloadFileProgram = () => {
-    
+
     // if (hasCampuses) {
     //   const selectedCampus = campusDetail?.find((element) => { return element?.campusName === selectedOption?.value })
     //   const curriculum = selectedCampus?.curriculumUrl
@@ -274,7 +274,7 @@ const ProgramSuperiorPageContent = (props: DynamicProgramDetailData) => {
                 variant: 'primary',
                 CTA: 'submit',
                 iconName: 'send',
-                action: () =>  {
+                action: () => {
                   return () =>
                     downloadFileProgram()
 

--- a/components/sections/ContEdProgramDetail.tsx
+++ b/components/sections/ContEdProgramDetail.tsx
@@ -40,17 +40,48 @@ const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramA
   const programDetail = parseEditorRawData(detail);
   const programImage = image?.data?.attributes;
   const programPriceDetail = parseEditorRawData(priceDetail);
+  const structuredData = JSON.stringify(seo?.structuredData)
 
   return (
     <ContentFullLayout>
       <Head>
-        {/* TODO: Add SEO */}
-        <meta property="og:title" content={ seo?.metaTitle }/>
-        <meta property="title" content={ seo?.metaTitle }/>
-        <meta property="og:description" content={ seo?.metaDescription }/>
-        <meta name="description" content={seo?.metaDescription} key="desc" />
-        <meta property="og:image" content={seo?.metaImage?.data?.attributes?.url}/>
-        <meta property="image" content={seo?.metaImage?.data?.attributes?.url}/>
+        {/* THIS DATA COMES FROM STRAPI SEO */}
+        <meta property="title" content={seo?.metaTitle} />{/* metaTitle */}
+        <meta name="description" content={seo?.metaDescription} key="desc" />{/* metaDescription */}
+        <meta property="image" content={seo?.metaImage?.data?.attributes?.url} />{/* metaImage */}
+        {/* metaSocial */}
+        {/* ARRAY COULD BRING FACEBOOK OR TWITTER */}
+        {
+          seo?.metaSocial?.map((metasocial) => {
+            if (metasocial?.socialNetwork === "Facebook") {
+              return (
+                <>
+                  <meta property="og:title" content={metasocial?.title} />
+                  <meta property="og:description" content={metasocial?.description} />
+                  <meta property="og:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            } if (metasocial?.socialNetwork === "Twitter") {
+              return (
+                <>
+                  <meta property="twitter:title" content={metasocial?.title} />
+                  <meta property="twitter:description" content={metasocial?.description} />
+                  <meta property="twitter:image" content={metasocial?.image?.data?.attributes?.url} />
+                </>
+              )
+            }
+          })
+        }
+        {/* keywords */}
+        <meta name="keywords" content={seo?.keywords} />
+        {/* metaRobots */}
+        <meta name="robots" content={seo?.metaRobots} />
+        {/* metaViewport */}
+        <meta name="viewport" content={seo?.metaViewport} />
+        {/* canonicalURL */}
+        <link rel="canonical" href={seo?.canonicalURL} />
+        {/* structuredData */}
+        <script type="application/ld+json">{structuredData}</script>
       </Head>
       <ContentLayout classNames="gap-6">
         {/* <div className="col-span-6 w-t:col-span-4 w-p:col-span-4 ">

--- a/components/sections/ContEdProgramDetail.tsx
+++ b/components/sections/ContEdProgramDetail.tsx
@@ -79,9 +79,9 @@ const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramA
         {/* metaViewport */}
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
-        <meta property="og:url" content={seo?.canonicalURL} />
+        <link rel="canonical" href={seo?.canonicalURL} />
         {/* ogURL */}
-        <link rel="og:url" href={seo?.canonicalURL} />
+        <meta property="og:url" content={seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/sections/ContEdProgramDetail.tsx
+++ b/components/sections/ContEdProgramDetail.tsx
@@ -80,6 +80,8 @@ const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramA
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
         <link rel="canonical" href={seo?.canonicalURL} />
+        {/* ogURL */}
+        <link rel="og:url" href={seo?.canonicalURL} />
         {/* structuredData */}
         <script type="application/ld+json">{structuredData}</script>
       </Head>

--- a/components/sections/ContEdProgramDetail.tsx
+++ b/components/sections/ContEdProgramDetail.tsx
@@ -79,7 +79,7 @@ const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramA
         {/* metaViewport */}
         <meta name="viewport" content={seo?.metaViewport} />
         {/* canonicalURL */}
-        <link rel="canonical" href={seo?.canonicalURL} />
+        <meta property="og:url" content={seo?.canonicalURL} />
         {/* ogURL */}
         <link rel="og:url" href={seo?.canonicalURL} />
         {/* structuredData */}

--- a/utils/getBlogEntryBySlug.ts
+++ b/utils/getBlogEntryBySlug.ts
@@ -33,6 +33,8 @@ query BlogEntryBySlug($slug: String) {
           }
         }
         seo {
+          metaTitle
+          metaDescription
           metaImage {
             data {
               attributes {
@@ -40,8 +42,23 @@ query BlogEntryBySlug($slug: String) {
               }
             }
           }
-          metaTitle
-          metaDescription
+          keywords
+          metaRobots
+          metaViewport
+          canonicalURL
+          structuredData
+          metaSocial {
+            socialNetwork
+            title
+            description
+            image {
+              data {
+                attributes {
+                  url
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/utils/getBlogPosts.ts
+++ b/utils/getBlogPosts.ts
@@ -1,5 +1,6 @@
 import { fetchStrapiGraphQL } from "@/utils/getStrapi";
 import type { StrapiImage } from "@/types/strapi/common";
+import { ReactNode } from "react";
 
 export type BlogPostsVariables = {
   start?: number;
@@ -9,7 +10,7 @@ export type BlogPostsVariables = {
 };
 
 const getBlogPosts = async (variables: BlogPostsVariables = {}) => {
-  
+
   const start = variables?.start || 0;
   const limit = variables?.limit;
   const sort = variables?.sort || "publication_date:desc";
@@ -25,6 +26,19 @@ const getBlogPosts = async (variables: BlogPostsVariables = {}) => {
   return data;
 };
 
+export type metaSocial = {
+  socialNetwork: String;
+  title: string;
+  description: string;
+  image: {
+    data: {
+      attributes: {
+        url: string;
+      }
+    }
+  }
+}
+
 export type BlogPost = {
   attributes: {
     title: string;
@@ -34,6 +48,12 @@ export type BlogPost = {
       metaTitle: string;
       metaDescription: string;
       metaImage: StrapiImage;
+      keywords: string;
+      metaRobots: string;
+      metaViewport: string;
+      canonicalURL: string;
+      structuredData: JSON;
+      metaSocial?: Array<metaSocial>
     }
     body: string;
     publication_date: string;
@@ -66,6 +86,23 @@ query BlogPosts ($start: Int, $limit: Int, $sort: [String], $category: String) {
             data {
               attributes {
                 url
+              }
+            }
+          }
+          keywords
+          metaRobots
+          metaViewport
+          canonicalURL
+          structuredData
+          metaSocial {
+            socialNetwork
+            title
+            description
+            image {
+              data {
+                attributes {
+                  url
+                }
               }
             }
           }

--- a/utils/getProgramBySlug.ts
+++ b/utils/getProgramBySlug.ts
@@ -93,6 +93,19 @@ export type programBrand = {
   }
 }
 
+export type metaSocial = {
+  socialNetwork: String;
+  title: string;
+  description: string;
+  image: {
+    data: {
+      attributes: {
+        url: string;
+      }
+    }
+  }
+}
+
 export type ProgramAttributes = {
   id?:number;
   slug: string;
@@ -107,6 +120,12 @@ export type ProgramAttributes = {
     metaTitle: string;
     metaDescription: string;
     metaImage: StrapiImage;
+    keywords: string;
+    metaRobots: string;
+    metaViewport: string;
+    canonicalURL: string;
+    structuredData: JSON;
+    metaSocial?: Array<metaSocial>
   }
   certifications: {
     data: Array<{
@@ -248,6 +267,23 @@ query ProgramBySlug($slug: String!) {
             data {
               attributes {
                 url
+              }
+            }
+          }
+          keywords
+          metaRobots
+          metaViewport
+          canonicalURL
+          structuredData
+          metaSocial {
+            socialNetwork
+            title
+            description
+            image {
+              data {
+                attributes {
+                  url
+                }
               }
             }
           }


### PR DESCRIPTION
## Issue
Add to the head the seo parameters from strapi

## Solution
- [X] Front use meta tags in blog for seo data from strapi aae80f7
- [X] Front use meta tags in program components for seo data from strapi 9310099
- [X] Redefine blog query to bring all data from seo 99a16d3
- [X] Redefine blog query to bring all data from seo part 2 adcf40b
- [X] Redefine programs query to bring all data from seo 8f05a17
- [X] Add ogUrl to the meta tags 47431a127962b20f401155312508ffae35d37a7e
- [X] Merge branch 'develop' into feat/LOT-1039 df92c678a14ab234f1a92240867e017942735e98
- [X] Replace link for meta url 82c9a25c662fa7c05fbe4615310e4a0da9b5f4ac
- [X] Fix link propertys 415205739faec4c17e062ca0b88bbe16755933ff
## Testing
<!-- Please describe the necessary steps for test your PR -->