### PR TITLE
[ADQ-170] fix oversize banner text width for text

### DIFF
--- a/old-components/BannerPortalverse.tsx
+++ b/old-components/BannerPortalverse.tsx
@@ -193,7 +193,7 @@ const BannerContent = (props: BannerPortalverseComponentData) => {
 
   return (
     <div className={desktopTabletContainerClasses}>
-      <div className="p-10">
+      <div className="p-10 desktop:w-1/2 tablet:w-2/3">
         {
           data?.title
             ? <h1


### PR DESCRIPTION
## Issue
Acortar texto del banner-hero desde Strapi para no tener líneas que ocupen el 100% de ancho

## Solution
- [X] fix oversize banner text width for text 4882bcec9e0cc0a7daf802483d77458a3905abf0
## Testing
<!-- Please describe the necessary steps for test your PR -->